### PR TITLE
Add option to hide individual combatant names from player view

### DIFF
--- a/client/Combatant/Combatant.ts
+++ b/client/Combatant/Combatant.ts
@@ -17,6 +17,7 @@ module ImprovedInitiative {
         StatBlock: KnockoutObservable<StatBlock>;
         GetInitiativeRoll: () => number;
         IsPlayerCharacter: boolean;
+        NameHidden: KnockoutObservable<boolean>;
     }
 
     export class Combatant implements Combatant {
@@ -68,6 +69,7 @@ module ImprovedInitiative {
         InitiativeGroup = ko.observable<string>(null);
         StatBlock = ko.observable<StatBlock>();
         Hidden = ko.observable(false);
+        NameHidden = ko.observable(false);
 
         IndexLabel: number;
         MaxHP: number;
@@ -103,6 +105,7 @@ module ImprovedInitiative {
             this.Alias(savedCombatant.Alias);
             this.Tags(Tag.getLegacyTags(savedCombatant.Tags, this));
             this.Hidden(savedCombatant.Hidden);
+            this.NameHidden(savedCombatant.NameHidden);
         }
 
         private getMaxHP(statBlock: StatBlock) {

--- a/client/Combatant/CombatantViewModel.ts
+++ b/client/Combatant/CombatantViewModel.ts
@@ -122,6 +122,10 @@ module ImprovedInitiative {
             return this.Combatant.Hidden() ? 'fa-eye-slash' : 'fa-eye';
         });
 
+        NameHiddenClass = ko.pureComputed(() => {
+            return this.Combatant.NameHidden() ? 'fa-question' : 'fa-info';
+        });
+
         IsSelected = ko.pureComputed(() => {
             return this.CombatantCommander.SelectedCombatants().some(c => c === this);
         });
@@ -138,6 +142,17 @@ module ImprovedInitiative {
             } else {
                 this.Combatant.Hidden(true);
                 this.LogEvent(`${this.Name()} hidden in player view.`);
+            }
+            this.Combatant.Encounter.QueueEmitEncounter();
+        }
+
+        ToggleNameHidden(data, event) {
+            if (this.Combatant.NameHidden()) {
+                this.Combatant.NameHidden(false);
+                this.LogEvent(`${this.Name()} name revealed in player view.`);
+            } else {
+                this.Combatant.NameHidden(true);
+                this.LogEvent(`${this.Name()} name hidden in player view.`);
             }
             this.Combatant.Encounter.QueueEmitEncounter();
         }

--- a/client/Combatant/StaticCombatantViewModel.ts
+++ b/client/Combatant/StaticCombatantViewModel.ts
@@ -9,7 +9,7 @@ module ImprovedInitiative {
         IsPlayerCharacter: boolean;
 
         constructor(combatant: Combatant) {
-            this.Name = combatant.DisplayName();
+            this.Name = this.GetName(combatant);
             this.Id = combatant.Id;
             this.HPDisplay = this.GetHPDisplay(combatant);
             this.HPColor = this.GetHPColor(combatant);
@@ -53,6 +53,14 @@ module ImprovedInitiative {
             var green = Math.floor((combatant.CurrentHP() / combatant.MaxHP) * 170);
             var red = Math.floor((combatant.MaxHP - combatant.CurrentHP()) / combatant.MaxHP * 170);
             return "rgb(" + red + "," + green + ",0)";
+        }
+
+        private GetName = (combatant: Combatant) => {
+            if (combatant.NameHidden()) {
+                return '???';
+            } else {
+                return combatant.DisplayName();
+            }
         }
     }
 }

--- a/client/Encounter/Encounter.ts
+++ b/client/Encounter/Encounter.ts
@@ -14,6 +14,7 @@ module ImprovedInitiative {
         Tags: string[] | SavedTag[];
         Hidden: boolean;
         InterfaceVersion: string;
+        NameHidden: boolean;
     }
     export interface SavedTag {
         Text: string;
@@ -267,7 +268,8 @@ module ImprovedInitiative {
                             DurationCombatantId: t.DurationCombatantId
                         })),
                         Hidden: c.Hidden(),
-                        InterfaceVersion: "1.0"
+                        InterfaceVersion: "1.0",
+                        NameHidden: c.NameHidden()
                     }
                 })
             };

--- a/html/templates/combatant.html
+++ b/html/templates/combatant.html
@@ -11,7 +11,8 @@
     </span>
 <!-- /ko -->
 </span>
-    <span class="buttons">
+<span class="buttons">
     <span class="fa-clickable fa-tag" title="Add note" data-bind="click: $root.CombatantCommander.AddTag"></span>
     <span class="fa-clickable" title="Hide/Reveal in Player Window" data-bind="click: ToggleHidden, css: HiddenClass"></span>
+    <span class="fa-clickable" title="Hide/Reveal name in Player Window" data-bind="click: ToggleNameHidden, css: NameHiddenClass"></span>
 </span>

--- a/lesscss/improved-initiative.less
+++ b/lesscss/improved-initiative.less
@@ -748,8 +748,12 @@ input[type="file"] {
     }
 
     .buttons {
-        width: 35px;
+        width: 60px;
         text-align: right;
+
+        .fa-info, .fa-question {
+            width: 10px;
+        }
     }
 }
 


### PR DESCRIPTION
It's not always clear to the players what they are fighting. This lets the DM toggle combatant names.

Being able to specify a encounter-specific name is also something I would like to do. Might work on that next.

This is something we needed for our game. Since the feature was fairly straightforward to implement I decided to submit it as a pull request.

P.S. it seems like installation fails with the newest allowed version of TypeScript, I had to revert to the earliest allowed version specified in package.json. Have you considered using [Yarn](http://yarnpkg.com/)?

Thank you for creating and maintaining this project!