### PR TITLE
115 encounter index labels

### DIFF
--- a/client/Combatant/Combatant.ts
+++ b/client/Combatant/Combatant.ts
@@ -5,6 +5,7 @@ import { CurrentSettings } from "../Settings/Settings";
 import { AbilityScores, StatBlock } from "../StatBlock/StatBlock";
 import { Metrics } from "../Utility/Metrics";
 import { probablyUniqueString } from "../Utility/Toolbox";
+import { combatantCountsByName } from "../Utility/Toolbox";
 import { Tag } from "./Tag";
 
 export interface Combatant {
@@ -131,24 +132,8 @@ export class Combatant implements Combatant {
     }
 
     private setIndexLabel(oldName?: string) {
-        let name = this.StatBlock().Name,
-            counts = this.Encounter.CombatantCountsByName();
-        if (name == oldName) {
-            return;
-        }
-        
-        if (!counts[oldName]) {
-            counts[oldName] = 1;
-        }
-        if (oldName) {
-            counts[oldName] = counts[oldName] - 1;
-        }
-
-        if (!counts[name]) {
-            counts[name] = 1;
-        } else {
-            counts[name] = counts[name] + 1;
-        }
+        let name = this.StatBlock().Name;
+        let counts = combatantCountsByName(name, this.Encounter.CombatantCountsByName(), oldName);
         this.IndexLabel = counts[name];
         this.Encounter.CombatantCountsByName(counts);
     }

--- a/client/Encounter/Encounter.ts
+++ b/client/Encounter/Encounter.ts
@@ -119,8 +119,15 @@ export class Encounter {
         this.emitEncounterTimeoutID = setTimeout(this.EmitEncounter, 10);
     }
 
-    public AddCombatantFromStatBlock = (statBlockJson: StatBlock, hideOnAdd = false, savedCombatant?: SavedCombatant) => {
+    public AddCombatantFromStatBlock = (statBlockJson: StatBlock, hideOnAdd = false, savedCombatant?: SavedCombatant, relabel?: boolean) => {
         const combatant = new Combatant(statBlockJson, this, savedCombatant);
+
+        if (relabel) {
+            let name = combatant.StatBlock().Name;
+            let counts = combatantCountsByName(name, this.CombatantCountsByName(), name);
+            combatant.IndexLabel = counts[name];
+            this.CombatantCountsByName(counts);
+        }
 
         if (hideOnAdd) {
             combatant.Hidden(true);
@@ -303,13 +310,7 @@ export class Encounter {
         const currentEncounterIsActive = this.State() == "active";
 
         savedEncounter.Combatants.forEach(c => {
-            const combatant = this.AddCombatantFromStatBlock(c.StatBlock, null, c);
-            if (!autosavedEncounter) {
-                let name = combatant.StatBlock().Name;
-                let counts = combatantCountsByName(name, this.CombatantCountsByName(), name);
-                combatant.IndexLabel = counts[name];
-                this.CombatantCountsByName(counts);
-            }
+            const combatant = this.AddCombatantFromStatBlock(c.StatBlock, null, c, !autosavedEncounter);
             if (currentEncounterIsActive) {
                 combatant.Initiative(combatant.GetInitiativeRoll());
             }

--- a/client/Utility/Toolbox.ts
+++ b/client/Utility/Toolbox.ts
@@ -25,6 +25,27 @@ export function probablyUniqueString(): string {
         let index = Math.floor(Math.random() * chars.length);
         probablyUniqueString += chars[index];
     }
-    
+
     return probablyUniqueString;
+}
+
+export function combatantCountsByName<T>(name: string, counts: T, oldName?: string): T {
+    console.log("name", name);
+    console.log("oldName", oldName);
+
+    if (name == oldName) { return counts; }
+
+    if (oldName) {
+        if (!counts[oldName]) { counts[oldName] = 1; }
+        counts[oldName] = counts[oldName] - 1;
+    }
+
+    if (!counts[name]) {
+        counts[name] = 1;
+    } else {
+        counts[name] = counts[name] + 1;
+    }
+
+    console.log("counts", counts);
+    return counts;
 }

--- a/client/Utility/Toolbox.ts
+++ b/client/Utility/Toolbox.ts
@@ -29,7 +29,7 @@ export function probablyUniqueString(): string {
     return probablyUniqueString;
 }
 
-export function combatantCountsByName<T>(name: string, counts: T, oldName?: string): T {
+export function combatantCountsByName(name: string, counts: { [name: string]: number }, oldName?: string): { [name: string]: number } {
     if (name == oldName) { return counts; }
     if (oldName) {
         if (!counts[oldName]) { counts[oldName] = 1; }

--- a/client/Utility/Toolbox.ts
+++ b/client/Utility/Toolbox.ts
@@ -30,22 +30,15 @@ export function probablyUniqueString(): string {
 }
 
 export function combatantCountsByName<T>(name: string, counts: T, oldName?: string): T {
-    console.log("name", name);
-    console.log("oldName", oldName);
-
     if (name == oldName) { return counts; }
-
     if (oldName) {
         if (!counts[oldName]) { counts[oldName] = 1; }
         counts[oldName] = counts[oldName] - 1;
     }
-
     if (!counts[name]) {
         counts[name] = 1;
     } else {
         counts[name] = counts[name] + 1;
     }
-
-    console.log("counts", counts);
     return counts;
 }


### PR DESCRIPTION
![ezgif com-optimize](https://user-images.githubusercontent.com/21250/36854758-bc93b4c8-1d3f-11e8-9927-b5aceabbb517.gif)

https://github.com/cynicaloptimist/improved-initiative/issues/115

When loading saved encounters, update the index labels of repeat combatants.

Previously, combatants added from a saved encounter would retain the index labels they were originally saved with often leading to duplicate indexes.

* Abstracts the inner workings of the private `Combatant.setIndexLabel` out to a reusable utility method
* Updates `Combatant.setIndexLabel` to call this method before setting the IndexLabel property and updating the `Encounter.CombatantCountsByName` observable
* Updates `Encounter.LoadSavedEncounter` to accept a boolean argument that indicates if it is an autoload event, which defaults to false
* Updates `Encounter`'s constructor method to specify that the initial call to `LoadSavedEncounter` is for an autoload
* Updates `Encounter.LoadSavedEncounter` to reset index labels on any load event that isn't an autoload 