### PR TITLE
Allow grouping of initiative for creatures of the same type

### DIFF
--- a/client/Combatant/Combatant.ts
+++ b/client/Combatant/Combatant.ts
@@ -23,6 +23,7 @@ export interface Combatant {
     InitiativeGroup: KnockoutObservable<string>;
     Hidden: KnockoutObservable<boolean>;
     StatBlock: KnockoutObservable<StatBlock>;
+    GetInitiativeRoll: () => number;
     IsPlayerCharacter: boolean;
 }
 
@@ -168,7 +169,7 @@ export class Combatant implements Combatant {
         return modifiers;
     }
 
-    public GetInitiativeRoll(): number {
+    public GetInitiativeRoll: () => number = () => {
         const sideInitiative = CurrentSettings().Rules.AutoGroupInitiative == 'Side Initiative';
         const initiativeBonus = sideInitiative ? 0 : this.InitiativeBonus;
         const initiativeAdvantage = (!sideInitiative && this.StatBlock().InitiativeAdvantage) ? "advantage" : null;

--- a/client/Combatant/CombatantViewModel.ts
+++ b/client/Combatant/CombatantViewModel.ts
@@ -28,7 +28,6 @@ export class CombatantViewModel {
             }
         });
         this.Name = Combatant.DisplayName;
-
         setTimeout(() => this.IsNew(false), 500);
     }
 

--- a/client/Commands/Prompts/InitiativePrompt.ts
+++ b/client/Commands/Prompts/InitiativePrompt.ts
@@ -1,5 +1,6 @@
 import { toModifierString } from "../../../common/Toolbox";
 import { Combatant } from "../../Combatant/Combatant";
+import { CurrentSettings } from "../../Settings/Settings";
 import { TutorialSpy } from "../../Tutorial/TutorialViewModel";
 import { Prompt } from "./Prompt";
 
@@ -12,8 +13,9 @@ export class InitiativePrompt implements Prompt {
 
     constructor(combatants: Combatant[], startEncounter: () => void) {
         const toPrompt = (combatant: Combatant) => {
-            const initiativeBonus = toModifierString(combatant.InitiativeBonus);
-            const advantageIndicator = combatant.StatBlock().InitiativeAdvantage ? "[adv]" : "";
+            const sideInitiative = CurrentSettings().Rules.AutoGroupInitiative == 'Side Initiative';
+            const initiativeBonus = sideInitiative ? 0 : toModifierString(combatant.InitiativeBonus);
+            const advantageIndicator = (!sideInitiative && combatant.StatBlock().InitiativeAdvantage) ? "[adv]" : "";
 
             return {
                 Id: combatant.Id,

--- a/client/Settings/Settings.ts
+++ b/client/Settings/Settings.ts
@@ -11,6 +11,7 @@ export interface Settings {
         RollMonsterHp: boolean;
         AllowNegativeHP: boolean;
         AutoCheckConcentration: boolean;
+        AutoGroupInitiative: string;
     };
     TrackerView: {
         DisplayRoundCounter: boolean;
@@ -20,6 +21,12 @@ export interface Settings {
     PlayerView: PlayerViewSettings;
     Version: string;
 }
+
+export const AutoGroupInitiativeOptions = [
+    "None",
+    "By Name",
+    "Side Initiative"
+];
 
 export const hpVerbosityOptions = [
     "Actual HP",
@@ -43,7 +50,8 @@ function getDefaultSettings(): Settings {
         Rules: {
             RollMonsterHp: false,
             AllowNegativeHP: false,
-            AutoCheckConcentration: true
+            AutoCheckConcentration: true,
+            AutoGroupInitiative: 'None'
         },
         TrackerView: {
             DisplayRoundCounter: false,
@@ -88,7 +96,8 @@ function getLegacySettings(): Settings {
         Rules: {
             RollMonsterHp: getLegacySetting<boolean>("RollMonsterHP", false),
             AllowNegativeHP: getLegacySetting<boolean>("AllowNegativeHP", false),
-            AutoCheckConcentration: getLegacySetting<boolean>("AutoCheckConcentration", true)
+            AutoCheckConcentration: getLegacySetting<boolean>("AutoCheckConcentration", true),
+            AutoGroupInitiative: getLegacySetting<string>("AutoGroupInitiative", 'None')
         },
         TrackerView: {
             DisplayRoundCounter: getLegacySetting<boolean>("DisplayRoundCounter", false),

--- a/client/Settings/Settings.ts
+++ b/client/Settings/Settings.ts
@@ -4,6 +4,8 @@ import { CommandSetting } from "../Commands/CommandSetting";
 import { Store } from "../Utility/Store";
 
 export const CurrentSettings = ko.observable<Settings>();
+export const AutoGroupInitiativeOptions = ["None", "By Name", "Side Initiative"];
+export type AutoGroupInitiativeOption = "None" | "By Name" | "Side Initiative";
 
 export interface Settings {
     Commands: CommandSetting[];
@@ -11,7 +13,7 @@ export interface Settings {
         RollMonsterHp: boolean;
         AllowNegativeHP: boolean;
         AutoCheckConcentration: boolean;
-        AutoGroupInitiative: string;
+        AutoGroupInitiative: AutoGroupInitiativeOption;
     };
     TrackerView: {
         DisplayRoundCounter: boolean;
@@ -22,11 +24,6 @@ export interface Settings {
     Version: string;
 }
 
-export const AutoGroupInitiativeOptions = [
-    "None",
-    "By Name",
-    "Side Initiative"
-];
 
 export const hpVerbosityOptions = [
     "Actual HP",
@@ -97,7 +94,7 @@ function getLegacySettings(): Settings {
             RollMonsterHp: getLegacySetting<boolean>("RollMonsterHP", false),
             AllowNegativeHP: getLegacySetting<boolean>("AllowNegativeHP", false),
             AutoCheckConcentration: getLegacySetting<boolean>("AutoCheckConcentration", true),
-            AutoGroupInitiative: getLegacySetting<string>("AutoGroupInitiative", 'None')
+            AutoGroupInitiative: getLegacySetting<AutoGroupInitiativeOption>("AutoGroupInitiative", 'None')
         },
         TrackerView: {
             DisplayRoundCounter: getLegacySetting<boolean>("DisplayRoundCounter", false),

--- a/client/Settings/SettingsViewModel.ts
+++ b/client/Settings/SettingsViewModel.ts
@@ -8,7 +8,7 @@ import { EncounterCommander } from "../Commands/EncounterCommander";
 import { Libraries } from "../Library/Libraries";
 import { AccountViewModel } from "../Settings/AccountViewModel";
 import { Store } from "../Utility/Store";
-import { AutoGroupInitiativeOptions, hpVerbosityOptions, CurrentSettings, Settings } from "./Settings";
+import { AutoGroupInitiativeOption, AutoGroupInitiativeOptions, hpVerbosityOptions, CurrentSettings, Settings } from "./Settings";
 import { CustomCSSEditor, CustomCSSEditorProps } from "./components/CustomCSSEditor";
 
 const tips = [
@@ -42,7 +42,7 @@ export class SettingsViewModel {
     public DisplayRoundCounter: KnockoutObservable<boolean>;
     public AutoCheckConcentration: KnockoutObservable<boolean>;
     public AutoGroupInitiativeOptions: string[];
-    public AutoGroupInitiative: KnockoutObservable<string>;
+    public AutoGroupInitiative: KnockoutObservable<AutoGroupInitiativeOption>;
     public AllowNegativeHP: KnockoutObservable<boolean>;
     public HideMonstersOutsideEncounter: KnockoutObservable<boolean>;
     public HpVerbosityOptions: string[];

--- a/client/Settings/SettingsViewModel.ts
+++ b/client/Settings/SettingsViewModel.ts
@@ -8,7 +8,7 @@ import { EncounterCommander } from "../Commands/EncounterCommander";
 import { Libraries } from "../Library/Libraries";
 import { AccountViewModel } from "../Settings/AccountViewModel";
 import { Store } from "../Utility/Store";
-import { hpVerbosityOptions, CurrentSettings, Settings } from "./Settings";
+import { AutoGroupInitiativeOptions, hpVerbosityOptions, CurrentSettings, Settings } from "./Settings";
 import { CustomCSSEditor, CustomCSSEditorProps } from "./components/CustomCSSEditor";
 
 const tips = [
@@ -41,6 +41,8 @@ export class SettingsViewModel {
     public DisplayTurnTimer: KnockoutObservable<boolean>;
     public DisplayRoundCounter: KnockoutObservable<boolean>;
     public AutoCheckConcentration: KnockoutObservable<boolean>;
+    public AutoGroupInitiativeOptions: string[];
+    public AutoGroupInitiative: KnockoutObservable<string>;
     public AllowNegativeHP: KnockoutObservable<boolean>;
     public HideMonstersOutsideEncounter: KnockoutObservable<boolean>;
     public HpVerbosityOptions: string[];
@@ -89,7 +91,8 @@ export class SettingsViewModel {
             Rules: {
                 AllowNegativeHP: this.AllowNegativeHP(),
                 AutoCheckConcentration: this.AutoCheckConcentration(),
-                RollMonsterHp: this.RollHp()
+                RollMonsterHp: this.RollHp(),
+                AutoGroupInitiative: this.AutoGroupInitiative(),
             },
             TrackerView: {
                 DisplayDifficulty: this.DisplayDifficulty(),
@@ -146,6 +149,8 @@ export class SettingsViewModel {
         this.RollHp = ko.observable(currentSettings.Rules.RollMonsterHp);
         this.AllowNegativeHP = ko.observable(currentSettings.Rules.AllowNegativeHP);
         this.AutoCheckConcentration = ko.observable(currentSettings.Rules.AutoCheckConcentration);
+        this.AutoGroupInitiative = ko.observable(currentSettings.Rules.AutoGroupInitiative);
+        this.AutoGroupInitiativeOptions = AutoGroupInitiativeOptions;
 
         this.DisplayRoundCounter = ko.observable(currentSettings.TrackerView.DisplayRoundCounter);
         this.DisplayTurnTimer = ko.observable(currentSettings.TrackerView.DisplayTurnTimer);

--- a/html/templates/settings.html
+++ b/html/templates/settings.html
@@ -63,6 +63,9 @@
     <p>Automatically prompt for concentration checks:
         <input type="checkbox" data-bind="checked: AutoCheckConcentration" />
     </p>
+    <p>Automatically group initiative rolls:
+        <select data-bind="options: AutoGroupInitiativeOptions, value: AutoGroupInitiative"></select>
+    </p>
     <h3>Encounter View</h3>
     <p>Display Round Counter:
         <input type="checkbox" data-bind="checked: DisplayRoundCounter" />


### PR DESCRIPTION
#116 

Allow automatic grouping of initiative

- Adds an option under Rules to "Automatically group initiative rolls
- Auto grouping options are "None", "By Name", and "Side Initiative"
- "None" makes no changes to initiative as it works now
- "By Name" causes new non-player combatants to be linked automatically to other combatants of the same name
- "Side Initiative" causes players to be grouped with other players, and non-player combatants to be linked to non-player combatants. In this case, neither side recieves roll modifiers
- Auto groupings are not immutable. Users are still able to move combatants, unlink them, and relink them manually
