### PR TITLE
Add basic Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+node_modules/*
+typings/*
+public/user/*
+public/fonts/*
+*.log
+*.js.map
+*.js
+*.css
+.tscache
+.vscode
+.baseDir
+!Gruntfile.js
+!*.config.js
+!*.config.prod.js
+!test/test.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:carbon
+ARG NODE_ENV
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$PATH:/home/node/.npm-global/bin
+RUN npm install -g grunt
+
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN grunt --no-color copy
+
+ENV NODE_ENV=${NODE_ENV}
+RUN if [ "$NODE_ENV" = "production" ]; then grunt --no-color build_min; else grunt --no-color build_dev; fi
+
+EXPOSE 80
+CMD [ "node", "server/server.js" ]

--- a/README.md
+++ b/README.md
@@ -28,5 +28,32 @@ You can configure your instance of Improved Initiative with these settings. All 
 * `KEEN_API_URL`, `KEEN_PROJECT_ID`, `KEEN_READ_KEY`, `KEEN_WRITE_KEY` - Configuration for metrics pipeline
 * `PATREON_URL`, `PATREON_CLIENT_ID`, `PATREON_CLIENT_SECRET` - Configuration for Patreon integration
 
-## Running with Docker
-Coming soon?
+## Docker
+
+Running Improved Initiative within Docker is possible, but completely optional and currently experimental. Proceed with caution and when in doubt, refer to the [Docker documentation](https://docs.docker.com/).
+
+### Building the Docker Image
+To build the docker image with a development build, run:
+
+`docker build -t improved-initiative:latest .`
+
+To build the image with a production build, run:
+
+`docker build --build-arg NODE_ENV=production -t improved-initiative:prod .`
+
+### Running the App in a Docker Container
+To start the application within the container, run:
+
+`docker run -p80:80 --name improved-initiative improved-initiative:latest`
+
+Or, to run the production build:
+
+`docker run -p80:80 --name improved-initiative improved-initiative:prod`
+
+### Stopping and Removing the Container
+
+Assuming you started the container with the name `improved-initiative` as shown above, the following commands will stop the container and then remove it:
+
+`docker stop improved-initiative`
+
+`docker rm improved-initiative`

--- a/README.md
+++ b/README.md
@@ -27,3 +27,6 @@ You can configure your instance of Improved Initiative with these settings. All 
 * `DB_CONNECTION_STRING` - Requires a mongoDB connection string if you'd like to support user accounts
 * `KEEN_API_URL`, `KEEN_PROJECT_ID`, `KEEN_READ_KEY`, `KEEN_WRITE_KEY` - Configuration for metrics pipeline
 * `PATREON_URL`, `PATREON_CLIENT_ID`, `PATREON_CLIENT_SECRET` - Configuration for Patreon integration
+
+## Running with Docker
+Coming soon?


### PR DESCRIPTION
I'm setting up a Dockerfile for my own local development environment. Any interest in having this merged in? I could add some docs to the README to show how to run it with Docker and add a docker-compose configuration to start it up with a running mongo server.