### PR TITLE
Visual Tweak - Fix #218

### DIFF
--- a/client/Components/Overlay.tsx
+++ b/client/Components/Overlay.tsx
@@ -8,13 +8,20 @@ interface OverlayProps {
     top?: number;
 }
 
-interface OverlayState { }
+interface OverlayState { 
+    height: number;
+}
 
 export class Overlay extends React.Component<OverlayProps, OverlayState> {
-    private height?: number;
+    constructor(props: OverlayProps) {
+        super(props);
+        this.state = {
+            height: null
+        };
+    }
 
     public render() {
-        const overflowAmount = Math.max((this.props.top || 0) + (this.height || 0) - window.innerHeight + 4, 0);
+        const overflowAmount = Math.max((this.props.top || 0) + this.state.height - window.innerHeight + 4, 0);
         const style: React.CSSProperties = {
             maxHeight: this.props.maxHeightPx || "100%",
             left: this.props.left || 0,
@@ -42,9 +49,10 @@ export class Overlay extends React.Component<OverlayProps, OverlayState> {
         let domElement = ReactDOM.findDOMNode(this);
         if (domElement instanceof Element) {
             let newHeight = domElement.getBoundingClientRect().height;
-            if (newHeight != this.height) {
-                this.height = newHeight;
-                this.forceUpdate();
+            if (newHeight != this.state.height) {
+                this.setState({ 
+                    height: newHeight,
+                });
             }
         }
     }

--- a/client/Components/Overlay.tsx
+++ b/client/Components/Overlay.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 interface OverlayProps {
     maxHeightPx?: number;
@@ -10,11 +11,14 @@ interface OverlayProps {
 interface OverlayState { }
 
 export class Overlay extends React.Component<OverlayProps, OverlayState> {
+    private height?: number;
+
     public render() {
+        const overflowAmount = Math.max((this.props.top || 0) + (this.height || 0) - window.innerHeight + 4, 0);
         const style: React.CSSProperties = {
             maxHeight: this.props.maxHeightPx || "100%",
             left: this.props.left || 0,
-            top: this.props.top || 0,
+            top: (this.props.top - overflowAmount) || 0,
         };
 
         return <div
@@ -24,5 +28,24 @@ export class Overlay extends React.Component<OverlayProps, OverlayState> {
             onMouseLeave={this.props.handleMouseEvents}>
             {this.props.children}
         </div>;
+    }
+
+    public componentDidMount() {
+        this.updateHeight();
+    }
+
+    public componentDidUpdate() {
+        this.updateHeight();
+    }
+
+    private updateHeight() {
+        let domElement = ReactDOM.findDOMNode(this);
+        if (domElement instanceof Element) {
+            let newHeight = domElement.getBoundingClientRect().height;
+            if (newHeight != this.height) {
+                this.height = newHeight;
+                this.forceUpdate();
+            }
+        }
     }
 }

--- a/lesscss/improved-initiative.less
+++ b/lesscss/improved-initiative.less
@@ -701,7 +701,6 @@ body>.login.button {
     
     flex-shrink: 1;
     overflow-y:auto;
-    padding-bottom: 25px;
 
     h3, h4 {
         margin-top: @medium-spacer;

--- a/lesscss/improved-initiative.less
+++ b/lesscss/improved-initiative.less
@@ -707,6 +707,7 @@ body>.login.button {
     }
     hr {
         margin: @small-spacer;
+        margin-bottom: 25px;
     }
     >div {
         flex-direction:row;

--- a/lesscss/improved-initiative.less
+++ b/lesscss/improved-initiative.less
@@ -701,13 +701,13 @@ body>.login.button {
     
     flex-shrink: 1;
     overflow-y:auto;
+    padding-bottom: 25px;
 
     h3, h4 {
         margin-top: @medium-spacer;
     }
     hr {
         margin: @small-spacer;
-        margin-bottom: 25px;
     }
     >div {
         flex-direction:row;


### PR DESCRIPTION
This resolves #218. It just works by calculating the amount an Overlay goes beyond the bottom of the window and shifting the overlay up by that amount (+4, for prettiness).

I meant to split this into two PRs but neglected to create a branch for each fix, so both commits got crammed into this one. Sorry about that.

Please let me know if there any changes you want made.