### PR TITLE
Fix hotkeys for new users

### DIFF
--- a/client/Settings/SettingsViewModel.ts
+++ b/client/Settings/SettingsViewModel.ts
@@ -163,6 +163,11 @@ export class SettingsViewModel {
         this.PreviousTip = cycleTipIndex.bind(-1);
 
         this.createEpicInitiativeSettingsComponent(currentSettings);
+
+        if (currentSettings.Commands.length === 0) {
+            // Loads initial set of commands for new users
+            this.SaveAndClose();
+        }
     }
 
     private createEpicInitiativeSettingsComponent(currentSettings: Settings) {


### PR DESCRIPTION
Re-saves the settings at startup if there aren't any commands. I'm curious if you see any drawbacks to this method, or whether there was a better way to fix it.