### PR TITLE
Don't advance player view if next combatant is hidden. Test skeleton.

### DIFF
--- a/client/Encounter/Encounter.ts
+++ b/client/Encounter/Encounter.ts
@@ -256,16 +256,18 @@ export class Encounter {
 
         this.ActiveCombatant(nextCombatant);
 
-        if (CurrentSettings().PlayerView.ActiveCombatantOnTop) {
-            this.ActiveCombatantToTop();
+        if (!nextCombatant.Hidden()) {
+            if (CurrentSettings().PlayerView.ActiveCombatantOnTop) {
+                this.ActiveCombatantToTop();
+            }
+
+            this.durationTags
+                .filter(t => t.HasDuration && t.DurationCombatantId == nextCombatant.Id && t.DurationTiming == "StartOfTurn")
+                .forEach(t => t.Decrement());
+
+            this.TurnTimer.Reset();
+            this.QueueEmitEncounter();
         }
-
-        this.durationTags
-            .filter(t => t.HasDuration && t.DurationCombatantId == nextCombatant.Id && t.DurationTiming == "StartOfTurn")
-            .forEach(t => t.Decrement());
-
-        this.TurnTimer.Reset();
-        this.QueueEmitEncounter();
     }
 
     public PreviousTurn = () => {

--- a/client/PlayerViewModel.test.ts
+++ b/client/PlayerViewModel.test.ts
@@ -125,4 +125,30 @@ describe("PlayerViewModel", () => {
         playerViewModel.LoadEncounter(encounter.SavePlayerDisplay());
         expect(playerViewModel.combatants()[0].HPDisplay).toBe("<span class='healthyHP'>Healthy</span>");
     });
+
+    test("Player View is only updated if next combatant is visible", () => {
+        const visibleCombatant1 = encounter.AddCombatantFromStatBlock(StatBlock.Default());
+        visibleCombatant1.Initiative(20);
+
+        const visibleCombatant2 = encounter.AddCombatantFromStatBlock(StatBlock.Default());
+        visibleCombatant2.Initiative(10);
+
+        const hiddenCombatant = encounter.AddCombatantFromStatBlock(StatBlock.Default());
+        hiddenCombatant.Hidden(true);
+        hiddenCombatant.Initiative(1);
+
+        encounter.StartEncounter();
+        playerViewModel.LoadEncounter(encounter.SavePlayerDisplay());
+
+        //expect(???).toBe(visibleCombatant1.Id);
+        encounter.NextTurn();
+
+        //expect(??).toBe(visibleCombatant2.Id);
+        encounter.NextTurn();
+
+        //expect(??).toBe(visibleCombatant2.Id);
+        encounter.NextTurn();
+
+        //expect(??).toBe(visibleCombatant1.Id);
+    });
 });


### PR DESCRIPTION
For #280

This implementation seems to work, but I'm not sure how best to test it, since the PlayerView has no unique concept of "Active Combatant". This means that the trick used elsewhere:

`const active = this.combatants().filter(c => c.Id == encounter.ActiveCombatantId).pop();`

won't work.

I've included a skeleton, but I need a bit of guidance on the best way to proceed. 