### PR TITLE
Fixes issue #293

### DIFF
--- a/client/Commands/EncounterCommander.test.ts
+++ b/client/Commands/EncounterCommander.test.ts
@@ -5,13 +5,13 @@ import {CurrentSettings, InitializeSettings} from "../Settings/Settings";
 import { Encounter } from "../Encounter/Encounter";
 import { StatBlock } from "../../common/StatBlock";
 
-describe("Encounter", () => {
+describe("EncounterCommander", () => {
     let encounter: Encounter;
     let encounterCommander: EncounterCommander;
     beforeEach(() => {
         InitializeSettings();
         encounter = buildEncounter();
-        encounter.StartEncounter();
+        encounterCommander.StartEncounter();
     });
 
     test("Start empty encounter.", () => {

--- a/client/Commands/EncounterCommander.test.ts
+++ b/client/Commands/EncounterCommander.test.ts
@@ -1,0 +1,37 @@
+import { buildEncounter } from "../test/buildEncounter";
+
+import { EncounterCommander } from  "./EncounterCommander";
+import {CurrentSettings, InitializeSettings} from "../Settings/Settings";
+import { Encounter } from "../Encounter/Encounter";
+import { StatBlock } from "../../common/StatBlock";
+
+describe("Encounter", () => {
+    let encounter: Encounter;
+    let encounterCommander: EncounterCommander;
+    beforeEach(() => {
+        InitializeSettings();
+        encounter = buildEncounter();
+        encounter.StartEncounter();
+    });
+
+    test("Start empty encounter.", () => {
+        expect(encounter.Combatants().length).toBe(0);
+        expect(!encounter.ActiveCombatant())
+    });
+
+    test("Click Next Turn with no combatants.", () => {
+        expect(!encounter.ActiveCombatant())
+        encounterCommander.NextTurn();
+        expect(encounter.RoundCounter() == 1);
+    });
+
+    test("Kickstart encounter after placing combatants.", () => {
+        const combatant = encounter.AddCombatantFromStatBlock(StatBlock.Default());
+        expect(!encounter.ActiveCombatant())
+        combatant.Initiative(combatant.GetInitiativeRoll());
+        encounterCommander.NextTurn();
+        expect(encounter.RoundCounter() == 1);
+        expect(encounter.Combatants()[0]).toBe(encounter.ActiveCombatant());
+
+    });
+});

--- a/client/Commands/EncounterCommander.test.ts
+++ b/client/Commands/EncounterCommander.test.ts
@@ -4,13 +4,23 @@ import { EncounterCommander } from  "./EncounterCommander";
 import {CurrentSettings, InitializeSettings} from "../Settings/Settings";
 import { Encounter } from "../Encounter/Encounter";
 import { StatBlock } from "../../common/StatBlock";
+import { TrackerViewModel } from "../TrackerViewModel";
 
 describe("EncounterCommander", () => {
     let encounter: Encounter;
     let encounterCommander: EncounterCommander;
+    let trackerViewModel: TrackerViewModel;
     beforeEach(() => {
         InitializeSettings();
+
+        const mockIo: any = {
+            on: jest.fn(),
+            emit: jest.fn()
+        };
+
+        trackerViewModel = new TrackerViewModel(mockIo);
         encounter = buildEncounter();
+        encounterCommander = trackerViewModel.EncounterCommander;
         encounterCommander.StartEncounter();
     });
 

--- a/client/Commands/EncounterCommander.ts
+++ b/client/Commands/EncounterCommander.ts
@@ -111,11 +111,12 @@ export class EncounterCommander {
 
     public NextTurn = () => {
         if (!this.tracker.Encounter.ActiveCombatant()) {
+            this.tracker.Encounter.ActiveCombatant(this.tracker.Encounter.Combatants()[0]);
             return;
         }
         const turnEndCombatant = this.tracker.Encounter.ActiveCombatant();
         if (turnEndCombatant) {
-            Metrics.TrackEvent("TurnCompleted", { Name: turnEndCombatant.DisplayName() });    
+            Metrics.TrackEvent("TurnCompleted", { Name: turnEndCombatant.DisplayName() });
         }
 
         this.tracker.Encounter.NextTurn();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "improved-initiative",
-  "version": "1.8.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
The [issue](https://github.com/cynicaloptimist/improved-initiative/issues/293) persisted through the ideas noted in the issue discussion. That was when I noticed [this](https://github.com/cynicaloptimist/improved-initiative/blob/551beb6760a37d6496a52176f17b11d39c5562dc/client/Commands/EncounterCommander.ts#L113), which held back the command from being even sent. 

I tackled the issue there by assigning the ActiveCombatant before returning, which cleanly resolves #293. This way the ActiveCombatant is set and ready without needlessly calling [NextTurn](https://github.com/cynicaloptimist/improved-initiative/blob/551beb6760a37d6496a52176f17b11d39c5562dc/client/Encounter/Encounter.ts#L242.). A needless call would also move and check duration tags, change the index and the round. It would therefore be too hackish to fix the issue from there.