### PR TITLE
#288

### DIFF
--- a/client/Importers/Importer.ts
+++ b/client/Importers/Importer.ts
@@ -36,10 +36,14 @@ export class Importer {
     public getCommaSeparatedModifiers(selector: string) {
         let entries = this.getCommaSeparatedStrings(selector);
         return entries.map(e => {
-            let nameAndModifier = e.split(" ");
+            // Extract the last piece of the name/modifier, and parse an int from only that, ensuring the name can contain any manner of spacing.
+            const nameAndModifier = e.split(" ");
+            const modifierValue = parseInt(nameAndModifier.pop());
+
+            // Join the remaining string name, and trim outside spacing just in case.
             return {
-                Name: nameAndModifier[0],
-                Modifier: parseInt(nameAndModifier[1])
+                Name: nameAndModifier.join(" ").trim(),
+                Modifier: modifierValue
             };
         });
     }

--- a/client/Importers/StatBlockImporter.test.ts
+++ b/client/Importers/StatBlockImporter.test.ts
@@ -54,6 +54,41 @@ describe("StatBlockImporter", () => {
         const result = new StatBlockImporter(monster).GetStatBlock();
         expect(result.Type).toEqual("Large aberration, lawful evil");
         expect(result.Source).toEqual("Monster Manual");
+    });
+
+    test("Save and skills strings should populate as Names and Modifiers correctly", () => {
+        const size = document.createElement("save");
+        size.innerHTML = "Con +3, Cha -1";
+        monster.appendChild(size);
+
+        const type = document.createElement("skill");
+        type.innerHTML = "Perception +4, Deception -2, Slight of Hand +2, Animal Handling +6";
+        monster.appendChild(type);
+
+        const result = new StatBlockImporter(monster).GetStatBlock();
+        expect(result.Saves).toEqual([
+            {
+                Name: "Con",
+                Modifier: 3
+            },
+            {
+                Name: "Cha",
+                Modifier: -1
+            }
+        ]);
+        expect(result.Skills).toEqual([{
+            Name: "Perception",
+            Modifier: 4
+        }, {
+            Name: "Deception",
+            Modifier: -2
+        }, {
+            Name: "Slight of Hand",
+            Modifier: 2
+        }, {
+            Name: "Animal Handling",
+            Modifier: 6
+        }]);
 
     });
 });


### PR DESCRIPTION
* Revising how the import handles save and skill modifier parsing to account for labels with spaces, while still properly obtaining a valid int for the modifier.
* Adding test case to validate the new functionality is sound.