### PR TITLE
Fix for showing bullets in statblock lists

### DIFF
--- a/lesscss/improved-initiative.less
+++ b/lesscss/improved-initiative.less
@@ -127,6 +127,10 @@ h4 {
   font-size: @font-size-h4;
 }
 
+ul {
+  list-style-position: inside;
+}
+
 ul.bulleted {
   padding-left: 40px;
 }

--- a/lesscss/improved-initiative.less
+++ b/lesscss/improved-initiative.less
@@ -127,10 +127,6 @@ h4 {
   font-size: @font-size-h4;
 }
 
-ul {
-  list-style-position: inside;
-}
-
 ul.bulleted {
   padding-left: 40px;
 }

--- a/lesscss/statblock.less
+++ b/lesscss/statblock.less
@@ -91,6 +91,7 @@
   .power-content {
     white-space: pre-line;
 
+    ol,
     ul {
       list-style-position: inside;
     }

--- a/lesscss/statblock.less
+++ b/lesscss/statblock.less
@@ -64,7 +64,7 @@
   flex-shrink: 1;
   overflow-y: auto;
   max-width: @fixed-column-width;
-  
+
   h3,
   h4 {
     display: flex;
@@ -90,6 +90,10 @@
 
   .power-content {
     white-space: pre-line;
+
+    ul {
+      list-style-position: inside;
+    }
   }
 
   .Abilities {


### PR DESCRIPTION
Using '*' characters in a statblocks correctly turns the items into a list but the bullets never show up so it just looks like a normal bunch of lines, this change fixes that and makes the bullets visible (instead of being off the left side of the page).

Before:
![image](https://user-images.githubusercontent.com/671500/50118551-d947d900-0204-11e9-8fd8-71534a46047b.png)

After:
![image](https://user-images.githubusercontent.com/671500/50118600-01373c80-0205-11e9-9dfc-c45bb37a4b0a.png)
