### PR TITLE
Add parentheses around default HP notes

### DIFF
--- a/common/StatBlock.ts
+++ b/common/StatBlock.ts
@@ -61,7 +61,7 @@ export class StatBlock {
         Name: "",
         Path: "",
         Source: "", Type: "",
-        HP: { Value: 1, Notes: "1d1+0" }, AC: { Value: 10, Notes: "" },
+        HP: { Value: 1, Notes: "(1d1+0)" }, AC: { Value: 10, Notes: "" },
         InitiativeModifier: 0,
         InitiativeAdvantage: false,
         Speed: [],


### PR DESCRIPTION
The standard format for HP has the random option surrounded by
parentheses, but the default template omits them.  Add them so users
can more easily follow the typical format.