### PR TITLE
Hide expired tags on Combatant Details

### DIFF
--- a/client/Combatant/CombatantDetails.tsx
+++ b/client/Combatant/CombatantDetails.tsx
@@ -28,13 +28,15 @@ export class CombatantDetails extends React.Component<
     }
 
     const currentHp = this.props.combatantViewModel.HP();
-    const tags = this.props.combatantViewModel.Combatant.Tags().map(tag => {
-      if (tag.HasDuration) {
-        return `${tag.Text} (${tag.DurationRemaining()} more rounds)`;
-      }
+    const tags = this.props.combatantViewModel.Combatant.Tags()
+      .filter(tag => tag.Visible())
+      .map(tag => {
+        if (tag.HasDuration) {
+          return `${tag.Text} (${tag.DurationRemaining()} more rounds)`;
+        }
 
-      return tag.Text;
-    });
+        return tag.Text;
+      });
 
     const notes = this.props.combatantViewModel.Combatant.CurrentNotes();
     const renderedNotes = notes ? this.props.enricher.EnrichText(notes) : null;

--- a/client/Encounter/Encounter.ts
+++ b/client/Encounter/Encounter.ts
@@ -390,6 +390,15 @@ export class Encounter {
       )
       .forEach(t => t.Decrement());
 
+    // Clean up expired tags
+    this.durationTags
+      .filter(t => t.DurationRemaining() <= 0)
+      .forEach(t => t.Remove());
+
+    this.durationTags = this.durationTags.filter(
+      t => t.DurationRemaining() > 0
+    );
+
     this.TurnTimer.Reset();
     this.QueueEmitEncounter();
   };

--- a/client/Encounter/Encounter.ts
+++ b/client/Encounter/Encounter.ts
@@ -390,15 +390,6 @@ export class Encounter {
       )
       .forEach(t => t.Decrement());
 
-    // Clean up expired tags
-    this.durationTags
-      .filter(t => t.DurationRemaining() <= 0)
-      .forEach(t => t.Remove());
-
-    this.durationTags = this.durationTags.filter(
-      t => t.DurationRemaining() > 0
-    );
-
     this.TurnTimer.Reset();
     this.QueueEmitEncounter();
   };


### PR DESCRIPTION
Fixes Issue #349 

Downside of this approach is previous turn will not restore the expired condition anymore.

Originally I considered removing the tag from `this.durationTags` on -1 instead of 0 (so you had a chance to do previous turn to restore), however you can end up with a condition where the tag disappears with 0 turns remaining on the stat block, then if you delete the monster which triggers the turn change, you have no way to restore or remove that tag anymore. This approach at least removes the tag everywhere as soon as it's no longer possible to manually remove it.