### PR TITLE
Use EffectiveExperience instead of EarnedExperience in combat-footer

### DIFF
--- a/html/tracker.html
+++ b/html/tracker.html
@@ -245,7 +245,7 @@
             <!-- ko if: Difficulty -->
             <span class="difficulty" data-bind="text: Difficulty"></span>
             <!-- /ko -->
-            <span data-bind="text: EarnedExperience"></span> XP
+            <span data-bind="text: EffectiveExperience"></span> XP
           </span>
           <!-- /ko -->
         </div>


### PR DESCRIPTION
The reported experience in the tracker footer does not take into account multipliers from creature hordes nor party size. Using EffectiveExperience does.

Resolves #358

Note: This is my first time doing pretty much everything in this MR. I am complete noob. I read the contributing guide and I followed as many directions as I could. Here are the ones I didn't follow and why I didn't follow them.

 1. The linked issue does not have a help-wanted tag.
 > I fixed it before I read the contributing guide and thought you could always just close this MR if there was a reason that the `help-wanted` tag was not on it.
 2. I did not include at least one test.
 > I don't think the project has any tests for any files in the `html` directory.