### PR TITLE
Use multiplier of 0.5 for large parties against 1 creature

### DIFF
--- a/client/Widgets/DifficultyCalculator.test.ts
+++ b/client/Widgets/DifficultyCalculator.test.ts
@@ -7,4 +7,14 @@ describe("Encounter Difficulty Calculator", () => {
     expect(difficulty.EarnedExperience).toBe(200);
     expect(difficulty.EffectiveExperience).toBe(200);
   });
+
+  it("11 CR, 6 Players", () => {
+    const difficulty = DifficultyCalculator.Calculate(
+      ["11"],
+      ["5", "5", "4", "4", "4", "4"]
+    );
+    expect(difficulty.Difficulty).toBe("Hard");
+    expect(difficulty.EarnedExperience).toBe(7200);
+    expect(difficulty.EffectiveExperience).toBe(3600);
+  });
 });

--- a/client/Widgets/DifficultyCalculator.ts
+++ b/client/Widgets/DifficultyCalculator.ts
@@ -70,7 +70,7 @@ const getTotalLevel = (levels: string) => {
   return levelStrings.map(i => parseInt(i)).reduce((p, c) => p + c, 0);
 };
 
-const rankedXpMultipliers = [1, 1, 1.5, 2, 2.5, 3, 4, 4];
+const rankedXpMultipliers = [0.5, 1, 1.5, 2, 2.5, 3, 4, 4];
 
 const getXpMultiplierRank = (enemyCount: number) => {
   if (enemyCount <= 1) {


### PR DESCRIPTION
While working on #118, I discovered that the effective experience calculated for 6 players vs 1 creature was wrong.

According to DMG p. 81: "If the party contains 6 or more characters, use the next lowest multiplier on the table. Use a multiplier of 0.5 for a single monster."