### PR TITLE
Do not ignore webpack configs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,5 +11,7 @@ public/fonts/*
 .baseDir
 !Gruntfile.js
 !*.config.js
+!*.config.base.js
+!*.config.dev.js
 !*.config.prod.js
 !test/test.js


### PR DESCRIPTION
The docker build for development is broken without these files being
available to grunt.