### PR TITLE
Make combatant portrait splash more responsive

### DIFF
--- a/lesscss/player-view.less
+++ b/lesscss/player-view.less
@@ -70,20 +70,24 @@
   .combatant-portrait {
     z-index: 2;
     position: absolute;
-    display: flex;
     align-items: center;
     width: 100%;
+    display: grid;
+    height: 80%;
   }
 
   .combatant-portrait__image {
     width: 80%;
-    max-width: 700px;
-    object-fit: scale-down;
+    object-fit: contain;
+    max-width: 80%;
+    max-height: 80vh;
+    margin: auto;
   }
 
   .combatant-portrait__caption {
     .card-bg-2(@large-spacer, @medium-spacer);
-    max-width: 700px;
+    margin: auto;
+    margin-top: 85vh;
   }
 
   .damage-suggestion {


### PR DESCRIPTION
Fixes #401 

Used excellent suggestions from @TheKrush and a little tweaking of my own to make the image fill the page in a responsive manner.

# Before:
![image](https://user-images.githubusercontent.com/1897006/61493076-9a7b2c80-a967-11e9-85cf-3e83714250ef.png)

# After:
![image](https://user-images.githubusercontent.com/1897006/61493103-aa930c00-a967-11e9-8737-9714cf08c7a6.png)

## More window sizes to show responsiveness:
![image](https://user-images.githubusercontent.com/1897006/61493157-c3032680-a967-11e9-9093-6d47c23a2759.png)

![image](https://user-images.githubusercontent.com/1897006/61493219-e3cb7c00-a967-11e9-99be-f10b32b82396.png)
