### PR TITLE
Removed unnecessary overflow to fix dialog clipping

### DIFF
--- a/lesscss/prompts.less
+++ b/lesscss/prompts.less
@@ -2,7 +2,6 @@
   padding: @medium-spacer;
   flex-shrink: 1;
   align-items: center;
-  overflow-y: auto;
   min-height: @prompt-minimum-height + (@medium-spacer * 4);
 
   &.empty {


### PR DESCRIPTION
This is a quick and dirty fix for issue: #81 

The auto complete dialog was being clipped by the overflow rules of the parent container.

A more long term solution might be to change how the autocomplete works, to move the dialog to be a sibling of the container and have it positioned dynamically.