### PR TITLE
Add creature to encounter as "boss" (max HP) or "minion" (1 HP)

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,11 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "none",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false,
+  "arrowParens": "avoid"
+}

--- a/client/Combatant/GetOrRollMaximumHP.test.ts
+++ b/client/Combatant/GetOrRollMaximumHP.test.ts
@@ -1,0 +1,41 @@
+import { StatBlock } from "../../common/StatBlock";
+import { CurrentSettings, InitializeSettings } from "../Settings/Settings";
+import { GetOrRollMaximumHP, VariantMaximumHP } from "./GetOrRollMaximumHP";
+
+describe("GetOrRollMaximumHP", () => {
+  let statBlock: StatBlock;
+
+  beforeEach(() => {
+    InitializeSettings();
+    statBlock = StatBlock.Default();
+    statBlock.HP = {
+      Value: 12, // Lower than the minimum to test rolling dice vs. using value
+      Notes: "8d10 + 16" // Average: 40 | Minimum: 24 | Maximum: 96
+    };
+  });
+
+  test("Should use stat block's HP value by default", () => {
+    const hp = GetOrRollMaximumHP(statBlock, VariantMaximumHP.DEFAULT);
+    expect(hp).toEqual(12);
+  });
+
+  test("Should roll stat block's HP if setting is enabled", () => {
+    const settings = CurrentSettings();
+    settings.Rules.RollMonsterHp = true;
+    CurrentSettings(settings);
+
+    const hp = GetOrRollMaximumHP(statBlock, VariantMaximumHP.DEFAULT);
+    expect(hp).toBeGreaterThanOrEqual(24);
+    expect(hp).toBeLessThanOrEqual(96);
+  });
+
+  test("Should return 1 HP for VariantMaximumHP.MINION", () => {
+    const hp = GetOrRollMaximumHP(statBlock, VariantMaximumHP.MINION);
+    expect(hp).toEqual(1);
+  });
+
+  test("Should return max rolled HP for VariantMaximumHP.BOSS", () => {
+    const hp = GetOrRollMaximumHP(statBlock, VariantMaximumHP.BOSS);
+    expect(hp).toEqual(96);
+  });
+});

--- a/client/Combatant/GetOrRollMaximumHP.ts
+++ b/client/Combatant/GetOrRollMaximumHP.ts
@@ -2,18 +2,31 @@ import { StatBlock } from "../../common/StatBlock";
 import { Dice } from "../Rules/Dice";
 import { CurrentSettings } from "../Settings/Settings";
 
-export function GetOrRollMaximumHP(statBlock: StatBlock) {
+export type VariantMaximumHP = "MINION" | "BOSS" | null;
+
+export function GetOrRollMaximumHP(
+  statBlock: StatBlock,
+  variant: VariantMaximumHP
+) {
   const rollMonsterHp = CurrentSettings().Rules.RollMonsterHp;
-  if (rollMonsterHp && statBlock.Player !== "player") {
-    try {
-      const rolledHP = Dice.RollDiceExpression(statBlock.HP.Notes).Total;
-      if (rolledHP > 0) {
-        return rolledHP;
-      }
+  if (statBlock.Player !== "player") {
+    if (variant == "MINION") {
       return 1;
-    } catch (e) {
-      console.error(e);
-      return statBlock.HP.Value;
+    } else if (variant == "BOSS" || rollMonsterHp) {
+      try {
+        const hpResult = Dice.RollDiceExpression(statBlock.HP.Notes);
+        if (variant == "BOSS") {
+          return hpResult.Maximum;
+        }
+        const rolledHP = hpResult.Total;
+        if (rolledHP > 0) {
+          return rolledHP;
+        }
+        return 1;
+      } catch (e) {
+        console.error(e);
+        return statBlock.HP.Value;
+      }
     }
   }
   return statBlock.HP.Value;

--- a/client/Combatant/GetOrRollMaximumHP.ts
+++ b/client/Combatant/GetOrRollMaximumHP.ts
@@ -2,7 +2,11 @@ import { StatBlock } from "../../common/StatBlock";
 import { Dice } from "../Rules/Dice";
 import { CurrentSettings } from "../Settings/Settings";
 
-export type VariantMaximumHP = "MINION" | "BOSS" | null;
+export enum VariantMaximumHP {
+  DEFAULT,
+  MINION,
+  BOSS
+}
 
 export function GetOrRollMaximumHP(
   statBlock: StatBlock,
@@ -10,12 +14,12 @@ export function GetOrRollMaximumHP(
 ) {
   const rollMonsterHp = CurrentSettings().Rules.RollMonsterHp;
   if (statBlock.Player !== "player") {
-    if (variant == "MINION") {
+    if (variant == VariantMaximumHP.MINION) {
       return 1;
-    } else if (variant == "BOSS" || rollMonsterHp) {
+    } else if (variant == VariantMaximumHP.BOSS || rollMonsterHp) {
       try {
         const hpResult = Dice.RollDiceExpression(statBlock.HP.Notes);
-        if (variant == "BOSS") {
+        if (variant == VariantMaximumHP.BOSS) {
           return hpResult.Maximum;
         }
         const rolledHP = hpResult.Total;

--- a/client/Commands/LibrariesCommander.ts
+++ b/client/Commands/LibrariesCommander.ts
@@ -5,6 +5,7 @@ import { PersistentCharacter } from "../../common/PersistentCharacter";
 import { Spell } from "../../common/Spell";
 import { StatBlock } from "../../common/StatBlock";
 import { probablyUniqueString } from "../../common/Toolbox";
+import { VariantMaximumHP } from "../Combatant/GetOrRollMaximumHP";
 import { Libraries } from "../Library/Libraries";
 import { Listing } from "../Library/Listing";
 import { StatBlockLibrary } from "../Library/StatBlockLibrary";
@@ -29,11 +30,16 @@ export class LibrariesCommander {
 
   public AddStatBlockFromListing = (
     listing: Listing<StatBlock>,
-    hideOnAdd: boolean
+    hideOnAdd: boolean,
+    variantMaximumHP: VariantMaximumHP
   ) => {
     listing.GetAsyncWithUpdatedId(unsafeStatBlock => {
       const statBlock = { ...StatBlock.Default(), ...unsafeStatBlock };
-      this.tracker.Encounter.AddCombatantFromStatBlock(statBlock, hideOnAdd);
+      this.tracker.Encounter.AddCombatantFromStatBlock(
+        statBlock,
+        hideOnAdd,
+        variantMaximumHP
+      );
       Metrics.TrackEvent("CombatantAdded", { Name: statBlock.Name });
       this.tracker.EventLog.AddEvent(`${statBlock.Name} added to combat.`);
     });

--- a/client/Encounter/Encounter.ts
+++ b/client/Encounter/Encounter.ts
@@ -11,7 +11,10 @@ import { PlayerViewCombatantState } from "../../common/PlayerViewCombatantState"
 import { StatBlock } from "../../common/StatBlock";
 import { probablyUniqueString } from "../../common/Toolbox";
 import { Combatant } from "../Combatant/Combatant";
-import { GetOrRollMaximumHP } from "../Combatant/GetOrRollMaximumHP";
+import {
+  GetOrRollMaximumHP,
+  VariantMaximumHP
+} from "../Combatant/GetOrRollMaximumHP";
 import { ToPlayerViewCombatantState } from "../Combatant/ToPlayerViewCombatantState";
 import { env } from "../Environment";
 import {
@@ -163,11 +166,15 @@ export class Encounter {
     return combatant;
   };
 
-  public AddCombatantFromStatBlock = (statBlockJson: {}, hideOnAdd = false) => {
+  public AddCombatantFromStatBlock = (
+    statBlockJson: {},
+    hideOnAdd = false,
+    variantMaximumHP: VariantMaximumHP = null
+  ) => {
     const statBlock: StatBlock = { ...StatBlock.Default(), ...statBlockJson };
     statBlock.HP = {
       ...statBlock.HP,
-      Value: GetOrRollMaximumHP(statBlock)
+      Value: GetOrRollMaximumHP(statBlock, variantMaximumHP)
     };
 
     const initialState: CombatantState = {

--- a/client/Encounter/Encounter.ts
+++ b/client/Encounter/Encounter.ts
@@ -169,7 +169,7 @@ export class Encounter {
   public AddCombatantFromStatBlock = (
     statBlockJson: {},
     hideOnAdd = false,
-    variantMaximumHP: VariantMaximumHP = null
+    variantMaximumHP: VariantMaximumHP = VariantMaximumHP.DEFAULT
   ) => {
     const statBlock: StatBlock = { ...StatBlock.Default(), ...statBlockJson };
     statBlock.HP = {

--- a/client/Library/Components/ListingButton.tsx
+++ b/client/Library/Components/ListingButton.tsx
@@ -7,6 +7,7 @@ interface Props {
   onClick: React.MouseEventHandler<HTMLSpanElement>;
   onMouseEnter?: React.MouseEventHandler<HTMLSpanElement>;
   onMouseLeave?: React.MouseEventHandler<HTMLSpanElement>;
+  title?: string;
   children?: React.ReactNode;
 }
 
@@ -28,6 +29,7 @@ export class ListingButton extends React.Component<Props> {
         onClick={this.props.onClick}
         onMouseEnter={this.props.onMouseEnter}
         onMouseLeave={this.props.onMouseLeave}
+        title={this.props.title}
       >
         {text} {this.props.children}
       </span>

--- a/client/Library/Components/ListingRow.tsx
+++ b/client/Library/Components/ListingRow.tsx
@@ -5,6 +5,13 @@ import { linkComponentToObservables } from "../../Combatant/linkComponentToObser
 import { Listing } from "../Listing";
 import { ListingButton } from "./ListingButton";
 
+export interface ExtraButton<T extends Listable> {
+  title: string;
+  buttonClass: string;
+  faClass: string;
+  onClick: (listing: Listing<T>, modified?: boolean) => void;
+}
+
 export interface ListingProps<T extends Listable> {
   name: string;
   listing: Listing<T>;
@@ -17,6 +24,7 @@ export interface ListingProps<T extends Listable> {
     e: React.MouseEvent<HTMLDivElement>
   ) => void;
   onPreviewOut?: (listing: Listing<T>) => void;
+  extraButtons?: ExtraButton<T>[];
   showCount?: boolean;
 }
 
@@ -42,6 +50,15 @@ export class ListingRow<T extends Listable> extends React.Component<
   private moveFn = () => this.props.onMove(this.props.listing);
   private previewFn = e => this.props.onPreview(this.props.listing, e);
   private previewOutFn = () => this.props.onPreviewOut(this.props.listing);
+  private makeExtraButtonFn = (extraButton: ExtraButton<T>) => {
+    if (!extraButton.onClick) {
+      return undefined;
+    }
+
+    return (event: React.MouseEvent<HTMLSpanElement>) => {
+      extraButton.onClick(this.props.listing, event.altKey);
+    };
+  };
 
   constructor(props) {
     super(props);
@@ -66,6 +83,16 @@ export class ListingRow<T extends Listable> extends React.Component<
         >
           {countElements}
         </ListingButton>
+        {this.props.extraButtons &&
+          this.props.extraButtons.map((button, index) => (
+            <ListingButton
+              key={index}
+              title={button.title}
+              buttonClass={button.buttonClass}
+              faClass={button.faClass}
+              onClick={this.makeExtraButtonFn(button)}
+            />
+          ))}
         {this.props.onDelete && (
           <ListingButton
             buttonClass="delete"

--- a/client/Library/Components/StatBlockLibraryPane.tsx
+++ b/client/Library/Components/StatBlockLibraryPane.tsx
@@ -3,13 +3,14 @@ import { StatBlock } from "../../../common/StatBlock";
 import { linkComponentToObservables } from "../../Combatant/linkComponentToObservables";
 import { LibrariesCommander } from "../../Commands/LibrariesCommander";
 import { StatBlockComponent } from "../../Components/StatBlock";
+import { CurrentSettings } from "../../Settings/Settings";
 import { TextEnricher } from "../../TextEnricher/TextEnricher";
 import { GetAlphaSortableLevelString } from "../../Utility/GetAlphaSortableLevelString";
 import { Listing } from "../Listing";
 import { StatBlockLibrary } from "../StatBlockLibrary";
 import { ListingGroupFn } from "./BuildListingTree";
 import { LibraryPane } from "./LibraryPane";
-import { ListingRow } from "./ListingRow";
+import { ExtraButton, ListingRow } from "./ListingRow";
 
 export type StatBlockLibraryPaneProps = {
   librariesCommander: LibrariesCommander;
@@ -101,8 +102,34 @@ export class StatBlockLibraryPane extends React.Component<
       onPreview={onPreview}
       onPreviewOut={onPreviewOut}
       listing={l}
+      extraButtons={
+        CurrentSettings().Rules.EnableBossAndMinionHP &&
+        this.bossAndMinionButtons
+      }
     />
   );
+
+  private loadSavedStatBlockAsMinion = (
+    listing: StatBlockListing,
+    hideOnAdd: boolean
+  ) => {
+    return this.props.librariesCommander.AddStatBlockFromListing(
+      listing,
+      hideOnAdd,
+      "MINION"
+    );
+  };
+
+  private loadSavedStatBlockAsBoss = (
+    listing: StatBlockListing,
+    hideOnAdd: boolean
+  ) => {
+    return this.props.librariesCommander.AddStatBlockFromListing(
+      listing,
+      hideOnAdd,
+      "BOSS"
+    );
+  };
 
   private loadSavedStatBlock = (
     listing: StatBlockListing,
@@ -110,7 +137,8 @@ export class StatBlockLibraryPane extends React.Component<
   ) => {
     return this.props.librariesCommander.AddStatBlockFromListing(
       listing,
-      hideOnAdd
+      hideOnAdd,
+      null
     );
   };
 
@@ -118,4 +146,19 @@ export class StatBlockLibraryPane extends React.Component<
     l.Listing.subscribe(_ => this.forceUpdate());
     this.props.librariesCommander.EditStatBlock(l, this.props.library);
   };
+
+  private bossAndMinionButtons: ExtraButton<StatBlock>[] = [
+    {
+      faClass: "chess-pawn",
+      buttonClass: "minion",
+      title: "Add with 1 HP",
+      onClick: this.loadSavedStatBlockAsMinion
+    },
+    {
+      faClass: "crown",
+      buttonClass: "boss",
+      title: "Add with maximum HP",
+      onClick: this.loadSavedStatBlockAsBoss
+    }
+  ];
 }

--- a/client/Library/Components/StatBlockLibraryPane.tsx
+++ b/client/Library/Components/StatBlockLibraryPane.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { StatBlock } from "../../../common/StatBlock";
+import { VariantMaximumHP } from "../../Combatant/GetOrRollMaximumHP";
 import { linkComponentToObservables } from "../../Combatant/linkComponentToObservables";
 import { LibrariesCommander } from "../../Commands/LibrariesCommander";
 import { StatBlockComponent } from "../../Components/StatBlock";
@@ -97,7 +98,7 @@ export class StatBlockLibraryPane extends React.Component<
       key={l.Listing().Id + l.Listing().Path + l.Listing().Name}
       name={l.Listing().Name}
       showCount
-      onAdd={this.loadSavedStatBlock}
+      onAdd={this.loadSavedStatBlock(VariantMaximumHP.DEFAULT)}
       onEdit={this.editStatBlock}
       onPreview={onPreview}
       onPreviewOut={onPreviewOut}
@@ -109,36 +110,14 @@ export class StatBlockLibraryPane extends React.Component<
     />
   );
 
-  private loadSavedStatBlockAsMinion = (
+  private loadSavedStatBlock = (variantMaximumHP: VariantMaximumHP) => (
     listing: StatBlockListing,
     hideOnAdd: boolean
   ) => {
     return this.props.librariesCommander.AddStatBlockFromListing(
       listing,
       hideOnAdd,
-      "MINION"
-    );
-  };
-
-  private loadSavedStatBlockAsBoss = (
-    listing: StatBlockListing,
-    hideOnAdd: boolean
-  ) => {
-    return this.props.librariesCommander.AddStatBlockFromListing(
-      listing,
-      hideOnAdd,
-      "BOSS"
-    );
-  };
-
-  private loadSavedStatBlock = (
-    listing: StatBlockListing,
-    hideOnAdd: boolean
-  ) => {
-    return this.props.librariesCommander.AddStatBlockFromListing(
-      listing,
-      hideOnAdd,
-      null
+      variantMaximumHP
     );
   };
 
@@ -152,13 +131,13 @@ export class StatBlockLibraryPane extends React.Component<
       faClass: "chess-pawn",
       buttonClass: "minion",
       title: "Add with 1 HP",
-      onClick: this.loadSavedStatBlockAsMinion
+      onClick: this.loadSavedStatBlock(VariantMaximumHP.MINION)
     },
     {
       faClass: "crown",
       buttonClass: "boss",
       title: "Add with maximum HP",
-      onClick: this.loadSavedStatBlockAsBoss
+      onClick: this.loadSavedStatBlock(VariantMaximumHP.BOSS)
     }
   ];
 }

--- a/client/Rules/RollResult.ts
+++ b/client/Rules/RollResult.ts
@@ -4,6 +4,9 @@ export class RollResult {
     public Modifier: number,
     public DieSize: number
   ) {}
+  get Maximum(): number {
+    return this.DieSize * this.Rolls.length + this.Modifier;
+  }
   get Total(): number {
     return this.Rolls.reduce((p, c) => c + p, 0) + this.Modifier;
   }

--- a/client/Rules/RollResults.test.ts
+++ b/client/Rules/RollResults.test.ts
@@ -1,0 +1,17 @@
+import { RollResult } from "./RollResult";
+
+describe("RollResult", () => {
+  let roll: RollResult;
+
+  beforeEach(() => {
+    roll = new RollResult([3, 6, 7], 4, 12);
+  });
+
+  test("Total", () => {
+    expect(roll.Total).toBe(20);
+  });
+
+  test("Maximum", () => {
+    expect(roll.Maximum).toBe(40);
+  });
+});

--- a/client/Settings/Settings.ts
+++ b/client/Settings/Settings.ts
@@ -50,10 +50,6 @@ function getLegacySettings(): Settings {
     Rules: {
       ...defaultSettings.Rules,
       RollMonsterHp: getLegacySetting<boolean>("RollMonsterHP", false),
-      EnableBossAndMinionHP: getLegacySetting<boolean>(
-        "EnableBossAndMinionHp",
-        false
-      ),
       AllowNegativeHP: getLegacySetting<boolean>("AllowNegativeHP", false),
       AutoCheckConcentration: getLegacySetting<boolean>(
         "AutoCheckConcentration",

--- a/client/Settings/Settings.ts
+++ b/client/Settings/Settings.ts
@@ -50,6 +50,10 @@ function getLegacySettings(): Settings {
     Rules: {
       ...defaultSettings.Rules,
       RollMonsterHp: getLegacySetting<boolean>("RollMonsterHP", false),
+      EnableBossAndMinionHP: getLegacySetting<boolean>(
+        "EnableBossAndMinionHp",
+        false
+      ),
       AllowNegativeHP: getLegacySetting<boolean>("AllowNegativeHP", false),
       AutoCheckConcentration: getLegacySetting<boolean>(
         "AutoCheckConcentration",

--- a/client/Settings/components/OptionsSettings.tsx
+++ b/client/Settings/components/OptionsSettings.tsx
@@ -19,6 +19,9 @@ export class OptionsSettings extends React.Component<OptionsSettingsProps> {
         <Toggle fieldName="Rules.RollMonsterHp">
           Roll HP when adding combatant from statblock
         </Toggle>
+        <Toggle fieldName="Rules.EnableBossAndMinionHP">
+          Choose maximum or minimum HP when adding combatant from statblock
+        </Toggle>
         <Toggle fieldName="Rules.AllowNegativeHP">
           Allow combatants to have negative hit points
         </Toggle>

--- a/common/Settings.ts
+++ b/common/Settings.ts
@@ -24,6 +24,7 @@ export interface Settings {
   Commands: CommandSetting[];
   Rules: {
     RollMonsterHp: boolean;
+    EnableBossAndMinionHP: boolean;
     AllowNegativeHP: boolean;
     AutoCheckConcentration: boolean;
     AutoGroupInitiative: AutoGroupInitiativeOption;
@@ -44,6 +45,7 @@ export function getDefaultSettings(): Settings {
     Commands: [],
     Rules: {
       RollMonsterHp: false,
+      EnableBossAndMinionHP: false,
       AllowNegativeHP: false,
       AutoCheckConcentration: true,
       AutoGroupInitiative: AutoGroupInitiativeOption.None,

--- a/lesscss/listing.less
+++ b/lesscss/listing.less
@@ -9,6 +9,8 @@
 }
 
 .c-listing {
+  .c-listing-boss,
+  .c-listing-minion,
   .c-listing-delete,
   .c-listing-edit,
   .c-listing-move,
@@ -17,6 +19,8 @@
   }
 
   &:hover {
+    .c-listing-boss,
+    .c-listing-minion,
     .c-listing-delete,
     .c-listing-edit,
     .c-listing-move {


### PR DESCRIPTION
This feature makes it easy to add "minions" (1 HP creatures) or "bosses" (creatures with maximum rolled HP) to the encounter straight from the creature library, without having to edit the combatant's stat block afterward.

Open to suggestions, especially around code structure, tests, or potential performance issues!

---

**The buttons on the creature listing:**

<img width="391" alt="library" src="https://user-images.githubusercontent.com/153104/67830594-98ba1c80-fab1-11e9-944a-e4ef8224e1bf.png">

---

**Four minion Acolytes and a max-HP hidden Aboleth:**

<img width="527" alt="encounter" src="https://user-images.githubusercontent.com/153104/67830595-98ba1c80-fab1-11e9-8754-63faec42fac0.png">

---

**Option to hide the buttons from the library:**

<img width="540" alt="settings" src="https://user-images.githubusercontent.com/153104/67830592-98ba1c80-fab1-11e9-9d92-8e97a9a163b1.png">
