### PR TITLE
Prevent default keypress event on hotkeys

### DIFF
--- a/client/Settings/Settings.ts
+++ b/client/Settings/Settings.ts
@@ -108,12 +108,7 @@ function applyNewCommandSettings(newSettings: Settings, commands: Command[]) {
   Mousetrap.reset();
 
   Mousetrap.bind("backspace", e => {
-    if (e.preventDefault) {
-      e.preventDefault();
-    } else {
-      // internet explorer
-      e.returnValue = false;
-    }
+    e.preventDefault();
   });
 
   commands.forEach(command => {
@@ -125,7 +120,10 @@ function applyNewCommandSettings(newSettings: Settings, commands: Command[]) {
       command.KeyBinding = commandSetting.KeyBinding;
       command.ShowOnActionBar(commandSetting.ShowOnActionBar);
     }
-    Mousetrap.bind(command.KeyBinding, command.ActionBinding);
+    Mousetrap.bind(command.KeyBinding, (e: Event, combo: string) => {
+      e.preventDefault();
+      command.ActionBinding();
+    });
   });
 }
 

--- a/client/Settings/Settings.ts
+++ b/client/Settings/Settings.ts
@@ -120,7 +120,7 @@ function applyNewCommandSettings(newSettings: Settings, commands: Command[]) {
       command.KeyBinding = commandSetting.KeyBinding;
       command.ShowOnActionBar(commandSetting.ShowOnActionBar);
     }
-    Mousetrap.bind(command.KeyBinding, (e: Event, combo: string) => {
+    Mousetrap.bind(command.KeyBinding, (e: Event) => {
       e.preventDefault();
       command.ActionBinding();
     });


### PR DESCRIPTION
Add `preventDefault()` to Command bindings to prevent special characters from being entered in commands that show and give focus to text inputs. Also removes an older `e.returnValue` call since that property has been deprecated in favor of `e.preventDefault`

fixes #416