### PR TITLE
Fixed statblock width at 900px

### DIFF
--- a/lesscss/responsive.less
+++ b/lesscss/responsive.less
@@ -38,8 +38,16 @@
     .left-column,
     .preview.statblock,
     .right-column {
-      width: 300px;
       max-width: 300px;
+    }
+
+    .c-statblock .Abilities {
+      margin: 0.5rem 0.25rem 0.5rem 0.25rem;
+    }
+
+    .c-statblock .Abilities div .score,
+    .c-statblock .Abilities div .modifier {
+      font-size: 0.75rem;
     }
   }
 }


### PR DESCRIPTION
Allowed statblock to go less than 300px when window width is < 900px. Caused Abilities statblock to become squished, so reduced font-size and margins.

Fixes #446 

Before:
![image](https://user-images.githubusercontent.com/507305/70664770-13da2b00-1c39-11ea-8a66-0d62690091db.png)
![image](https://user-images.githubusercontent.com/507305/70664797-1fc5ed00-1c39-11ea-8350-20c237f14274.png)

After:
![image](https://user-images.githubusercontent.com/507305/70664813-2b191880-1c39-11ea-84b4-57c9e52abf28.png)
![image](https://user-images.githubusercontent.com/507305/70664864-497f1400-1c39-11ea-95ae-0d1931ff0d56.png)

