### PR TITLE
[CONFIG] Extract out jest config, add adapter setup file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ public/webfonts/*
 *.log
 *.js.map
 *.js
+!jest.config.js
 *.css
 *.tmp.txt
 *.gitignore.*

--- a/client/Commands/Toolbar.test.tsx
+++ b/client/Commands/Toolbar.test.tsx
@@ -1,12 +1,9 @@
 import * as Enzyme from "enzyme";
-import * as Adapter from "enzyme-adapter-react-16";
 import * as React from "react";
 
 import { Button } from "../Components/Button";
 import { Command } from "./Command";
 import { Toolbar } from "./Toolbar";
-
-Enzyme.configure({ adapter: new Adapter() });
 
 const renderToolbarWithSingleCommand = (id, description, keyBinding) => {
   const encounterCommands = [

--- a/client/Components/StatBlock.test.tsx
+++ b/client/Components/StatBlock.test.tsx
@@ -1,13 +1,10 @@
 import * as Enzyme from "enzyme";
-import * as Adapter from "enzyme-adapter-react-16";
 import * as React from "react";
 
 import { StatBlock } from "../../common/StatBlock";
 import { DefaultRules } from "../Rules/Rules";
 import { buildStatBlockTextEnricher } from "../test/buildStatBlockTextEnricher";
 import { StatBlockComponent } from "./StatBlock";
-
-Enzyme.configure({ adapter: new Adapter() });
 
 describe("StatBlock component", () => {
   test("Shows the statblock's name", () => {

--- a/client/Player/PlayerView.test.tsx
+++ b/client/Player/PlayerView.test.tsx
@@ -1,5 +1,4 @@
 import * as Enzyme from "enzyme";
-import * as Adapter from "enzyme-adapter-react-16";
 import * as React from "react";
 
 import { TagState } from "../../common/CombatantState";
@@ -11,8 +10,6 @@ import { buildEncounter } from "../test/buildEncounter";
 import { PlayerView } from "./components/PlayerView";
 import { PlayerViewCombatant } from "./components/PlayerViewCombatant";
 import { PortraitWithCaption } from "./components/PortraitModal";
-
-Enzyme.configure({ adapter: new Adapter() });
 
 describe("PlayerViewModel", () => {
   let encounter: Encounter;

--- a/client/Player/TurnTimer.test.tsx
+++ b/client/Player/TurnTimer.test.tsx
@@ -1,5 +1,4 @@
 import * as Enzyme from "enzyme";
-import * as Adapter from "enzyme-adapter-react-16";
 import * as React from "react";
 
 import { StatBlock } from "../../common/StatBlock";
@@ -7,8 +6,6 @@ import { Encounter } from "../Encounter/Encounter";
 import { InitializeSettings } from "../Settings/Settings";
 import { buildEncounter } from "../test/buildEncounter";
 import { CombatFooter } from "./components/CombatFooter";
-
-Enzyme.configure({ adapter: new Adapter() });
 
 describe("Turn Timer", () => {
   let encounter: Encounter;

--- a/client/StatBlockEditor/StatBlockEditor.test.tsx
+++ b/client/StatBlockEditor/StatBlockEditor.test.tsx
@@ -1,5 +1,4 @@
 import * as Enzyme from "enzyme";
-import * as Adapter from "enzyme-adapter-react-16";
 import * as React from "react";
 
 import { StatBlockEditor } from "./StatBlockEditor";
@@ -9,8 +8,6 @@ import { Listing } from "../Library/Listing";
 
 const CURRENT_APP_VERSION = require("../../package.json").version;
 process.env.VERSION = CURRENT_APP_VERSION;
-
-Enzyme.configure({ adapter: new Adapter() });
 
 describe("StatBlockEditor", () => {
   let editor: Enzyme.ReactWrapper<any, any>;

--- a/client/TextEnricher/TextEnricher.test.tsx
+++ b/client/TextEnricher/TextEnricher.test.tsx
@@ -1,13 +1,10 @@
 import * as Enzyme from "enzyme";
-import * as Adapter from "enzyme-adapter-react-16";
 import { Spell } from "../../common/Spell";
 import { AccountClient } from "../Account/AccountClient";
 import { SpellLibrary } from "../Library/SpellLibrary";
 import { DefaultRules } from "../Rules/Rules";
 import { Store } from "../Utility/Store";
 import { TextEnricher } from "./TextEnricher";
-
-Enzyme.configure({ adapter: new Adapter() });
 
 describe("TextEnricher", () => {
   test("Spell Reference", async done => {

--- a/client/test/adapterSetup.ts
+++ b/client/test/adapterSetup.ts
@@ -1,0 +1,4 @@
+import * as Enzyme from "enzyme";
+import * as Adapter from "enzyme-adapter-react-16";
+
+Enzyme.configure({ adapter: new Adapter() });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,32 @@
+module.exports = {
+  globals: {
+    "ts-jest": {
+      "tsConfig": "client/tsconfig.json"
+    }
+  },
+  setupFiles: [
+    "jest-localstorage-mock",
+    "./client/test/adapterSetup.ts"
+  ],
+  transform: {
+    "^.+\\.tsx?$": "ts-jest",
+    "^.+\\.md?$": "markdown-loader-jest"
+  },
+  testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+  moduleFileExtensions: [
+    "ts",
+    "tsx",
+    "js",
+    "jsx",
+    "json",
+    "node"
+  ],
+  moduleNameMapper: {
+    "^dnd-core$": "dnd-core/dist/cjs",
+    "^react-dnd$": "react-dnd/dist/cjs",
+    "^react-dnd-html5-backend$": "react-dnd-html5-backend/dist/cjs",
+    "^react-dnd-touch-backend$": "react-dnd-touch-backend/dist/cjs",
+    "^react-dnd-test-backend$": "react-dnd-test-backend/dist/cjs",
+    "^react-dnd-test-utils$": "react-dnd-test-utils/dist/cjs"
+  }
+};

--- a/package.json
+++ b/package.json
@@ -115,37 +115,6 @@
     "socket.io-client": "^2.1.1",
     "socket.io-redis": "^5.2.0"
   },
-  "jest": {
-    "globals": {
-      "ts-jest": {
-        "tsConfig": "client/tsconfig.json"
-      }
-    },
-    "setupFiles": [
-      "jest-localstorage-mock"
-    ],
-    "transform": {
-      "^.+\\.tsx?$": "ts-jest",
-      "^.+\\.md?$": "markdown-loader-jest"
-    },
-    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json",
-      "node"
-    ],
-    "moduleNameMapper": {
-      "^dnd-core$": "dnd-core/dist/cjs",
-      "^react-dnd$": "react-dnd/dist/cjs",
-      "^react-dnd-html5-backend$": "react-dnd-html5-backend/dist/cjs",
-      "^react-dnd-touch-backend$": "react-dnd-touch-backend/dist/cjs",
-      "^react-dnd-test-backend$": "react-dnd-test-backend/dist/cjs",
-      "^react-dnd-test-utils$": "react-dnd-test-utils/dist/cjs"
-    }
-  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"


### PR DESCRIPTION
Adapter setup file recommended here https://github.com/airbnb/enzyme/blob/master/docs/guides/jest.md and it cleans up a bunch of tests files. I pulled out the jest config because I find it's easier to parse out the settings when they're not in the same bucket as `package.json` .