### PR TITLE
Change 0 CR to 10xp

### DIFF
--- a/client/Widgets/DifficultyCalculator.test.ts
+++ b/client/Widgets/DifficultyCalculator.test.ts
@@ -17,4 +17,11 @@ describe("Encounter Difficulty Calculator", () => {
     expect(difficulty.EarnedExperience).toBe(7200);
     expect(difficulty.EffectiveExperience).toBe(3600);
   });
+
+  it("4 CR 0, no Players", () => {
+    const difficulty = DifficultyCalculator.Calculate(["0", "0", "0", "0"], []);
+    expect(difficulty.Difficulty).toBe("");
+    expect(difficulty.EarnedExperience).toBe(40);
+    expect(difficulty.EffectiveExperience).toBe(40);
+  });
 });

--- a/client/Widgets/DifficultyCalculator.ts
+++ b/client/Widgets/DifficultyCalculator.ts
@@ -29,7 +29,7 @@ const xpThresholdsByLevel: { [level: number]: XpThresholds } = {
 };
 
 const xpAmountsByChallenge = {
-  "0": 0,
+  "0": 10,
   "1/8": 25,
   "1/4": 50,
   "1/2": 100,


### PR DESCRIPTION
This one is up to you whether you think it's a valid change or not. Seems like most of the CR 0 monsters grant 10xp rather than 0, and very few grant 0 XP (frog, seahorse, only those with no effective attacks). I could also see the merit of keeping 0 CR as 0 XP for the sake of lair actions and other non-combatants. The XP change would really only impact very low level games anyways.

Unrelated note, after using the latest development, `lint-staged` wouldn't run on pre-commit, no idea why, tried `npm install` several times, updated node to the latest LTS, and a few things to re-setup lint-staged. I was using node 12.13.1 previously. I ended up having to do a --no-verify to bypass.

![image](https://user-images.githubusercontent.com/507305/103318372-45689480-49fc-11eb-9b05-aaff961f9e96.png)
