### PR TITLE
Add optional HP bar for active/selected combatants in Encounter view

### DIFF
--- a/client/Combatant/CombatantDetails.tsx
+++ b/client/Combatant/CombatantDetails.tsx
@@ -5,6 +5,7 @@ import { StatBlockHeader } from "../Components/StatBlockHeader";
 import { TextEnricherContext } from "../TextEnricher/TextEnricher";
 import { CombatantViewModel } from "./CombatantViewModel";
 import { useSubscription } from "./linkComponentToObservables";
+import { SettingsContext } from "../Settings/SettingsContext";
 import { Tag } from "./Tag";
 import { useContext } from "react";
 
@@ -17,6 +18,7 @@ interface CombatantDetailsProps {
 export function CombatantDetails(props: CombatantDetailsProps) {
   const TextEnricher = useContext(TextEnricherContext);
   const currentHp = useSubscription(props.combatantViewModel.HP);
+  const currentHPPercentage = useSubscription(props.combatantViewModel.HPPercentage);
   const name = useSubscription(props.combatantViewModel.Name);
   const tags = useSubscription(props.combatantViewModel.Combatant.Tags);
   const notes = useSubscription(
@@ -26,6 +28,7 @@ export function CombatantDetails(props: CombatantDetailsProps) {
     props.combatantViewModel.Combatant.StatBlock
   );
 
+  const { DisplayHPBar } = useContext(SettingsContext).TrackerView;
   if (!props.combatantViewModel) {
     return null;
   }
@@ -47,7 +50,15 @@ export function CombatantDetails(props: CombatantDetailsProps) {
         imageUrl={statBlock.ImageURL}
       />
       <div className="c-combatant-details__hp">
-        <span className="stat-label">Current HP</span> {currentHp}
+        <span className="stat-label">Current HP</span>
+        <span>
+          {currentHp}
+          {DisplayHPBar && (
+            <span className="combatant__hp-bar">
+              <span className="combatant__hp-bar--filled" style={renderHPBarStyle(currentHPPercentage)}/>
+            </span>
+          )}
+        </span>
       </div>
       {tags.length > 0 && (
         <div className="c-combatant-details__tags">
@@ -89,4 +100,7 @@ function TagDetails(props: { tag: Tag }) {
   }
 
   return <>{props.tag.Text}</>;
+}
+function renderHPBarStyle(currentHPPercentage) {
+  return {width: currentHPPercentage };
 }

--- a/client/Combatant/CombatantViewModel.ts
+++ b/client/Combatant/CombatantViewModel.ts
@@ -16,6 +16,7 @@ const animatedCombatantIds = ko.observableArray<string>([]);
 
 export class CombatantViewModel {
   public HP: KnockoutComputed<string>;
+  public HPPercentage: KnockoutComputed<string>;
   public Name: KnockoutComputed<string>;
 
   constructor(
@@ -30,6 +31,10 @@ export class CombatantViewModel {
       } else {
         return `${this.Combatant.CurrentHP()}/${this.Combatant.MaxHP()}`;
       }
+    });
+    this.HPPercentage = ko.pureComputed(() => {
+      console.log(this.Combatant.CurrentHP());
+      return Math.floor((this.Combatant.CurrentHP() / this.Combatant.MaxHP()) * 100)+'%';
     });
     this.Name = Combatant.DisplayName;
     setTimeout(() => animatedCombatantIds.push(this.Combatant.Id), 500);

--- a/client/InitiativeList/CombatantRow.tsx
+++ b/client/InitiativeList/CombatantRow.tsx
@@ -27,6 +27,7 @@ export function CombatantRow(props: CombatantRowProps) {
   const commandContext = React.useContext(CommandContext);
 
   const { DisplayPortraits } = React.useContext(SettingsContext).TrackerView;
+  const { DisplayHPBar } = React.useContext(SettingsContext).TrackerView;
 
   const { combatantState, isSelected, isActive } = props;
   const { StatBlock } = combatantState;
@@ -137,6 +138,11 @@ export function CombatantRow(props: CombatantRowProps) {
         />
 
         {renderHPText(props)}
+        {DisplayHPBar && (
+          <span className="combatant__hp-bar">
+            <span className="combatant__hp-bar--filled" style={renderHPBarStyle(props)}/>
+          </span>
+        )}
       </td>
 
       <td className="combatant__ac">
@@ -234,4 +240,9 @@ function renderHPText(props: CombatantRowProps) {
   } else {
     return `${props.combatantState.CurrentHP}/${maxHP}`;
   }
+}
+function renderHPBarStyle(props: CombatantRowProps) {
+  const maxHP = props.combatantState.StatBlock.HP.Value,
+    currentHP = props.combatantState.CurrentHP;
+  return {width: Math.floor((currentHP / maxHP) * 100) + "%" };
 }

--- a/client/Settings/components/OptionsSettings.tsx
+++ b/client/Settings/components/OptionsSettings.tsx
@@ -81,6 +81,13 @@ export function OptionsSettings(props: {
           Creatures and Non Player Characters are counted as enemies.
         </Info>
       </Toggle>
+      <Toggle fieldName="TrackerView.DisplayHPBar">
+        Display HP Bar of Active or Selected Character
+        <Info>
+          Show a small HP bar indicator for any selected combatant(s),
+          as well as for the currently-active combatant.
+        </Info>
+      </Toggle>
       <Dropdown
         fieldName="TrackerView.PostCombatStats"
         options={PostCombatStatsOption}

--- a/common/Settings.ts
+++ b/common/Settings.ts
@@ -35,6 +35,7 @@ export interface Settings {
     DisplayRoundCounter: boolean;
     DisplayTurnTimer: boolean;
     DisplayDifficulty: boolean;
+    DisplayHPBar: boolean;
     PostCombatStats: PostCombatStatsOption;
   };
   PlayerView: PlayerViewSettings;
@@ -57,6 +58,7 @@ export function getDefaultSettings(): Settings {
       DisplayRoundCounter: false,
       DisplayTurnTimer: false,
       DisplayDifficulty: true,
+      DisplayHPBar: false,
       PostCombatStats: PostCombatStatsOption.None
     },
     PlayerView: {

--- a/lesscss/components/combatants.less
+++ b/lesscss/components/combatants.less
@@ -66,6 +66,42 @@
   }
 }
 
+.combatant__hp-bar {
+  display: block;
+  height:3px;
+  background: #c00;
+  text-align: left;
+  position: relative;
+  margin-bottom:-3px;
+  .combatant__hp-bar--filled {
+    display: inline-block;
+    height: inherit;
+    background: #0c0;
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    transition: width .5s;
+  }
+}
+
+// hidden from encounter view by default
+.combatant {
+  .combatant__hp-bar {
+    transition: opacity .3s;
+    opacity: 0;
+  }
+}
+// becomes visible for active/selected combatants, or on hover
+.combatant.active,
+.combatant.selected,
+.combatant__hp:hover {
+  .combatant__hp-bar {
+    opacity: 1;
+  }
+}
+
+
 .combatant {
   padding: @medium-spacer;
   height: 2.2rem;


### PR DESCRIPTION
This adds an HP bar for a quick/intuitive visual indicator on the active/selected combatant sidebars, and (on full-sized screens) within the combatant list. So as to not clutter an already information-dense view, this only appears on the active and any selected combatants.

![improved-initiative-hp-bar](https://user-images.githubusercontent.com/85644845/121448213-c8ebc180-c95c-11eb-8e0c-b90300db2c57.png)

Also, since this is something that might not be everyone's cup of tea, there's a toggle in the Options to turn it off (and it's off by default).

![improved-initiative-hp-bar-toggle](https://user-images.githubusercontent.com/85644845/121448384-26800e00-c95d-11eb-8a39-8796cf35932d.png)

Note: this is strictly for the encounter view. I could easily see adding this as an option to the player view, too.