### PR TITLE
flips icon direction when toggling wide/narrow toolbar

### DIFF
--- a/client/Components/Button.tsx
+++ b/client/Components/Button.tsx
@@ -21,19 +21,21 @@ export function Button(props: ButtonProps) {
 
   const classNames = ["c-button"];
 
-  if (props.disabled) {
-    classNames.push("c-button--disabled");
-  }
+  const faElement = props.fontAwesomeIcon && (
+    <span className={`fas fa-${props.fontAwesomeIcon}${
+        (props.text && props.additionalClassNames == "c-button--toggle-menu") ? " fa-flip-horizontal" : ""
+      }`} />
+  );
   if (props.fontAwesomeIcon && props.text) {
     classNames.push("c-button--icon-and-text");
+  }
+
+  if (props.disabled) {
+    classNames.push("c-button--disabled");
   }
   if (props.additionalClassNames) {
     classNames.push(props.additionalClassNames);
   }
-
-  const faElement = props.fontAwesomeIcon && (
-    <span className={`fas fa-${props.fontAwesomeIcon}`} />
-  );
 
   const button = (
     <button


### PR DESCRIPTION
This is a tiny adjustment to make the toolbar toggle marginally more intuitive. It leverages FontAwesome's rotation classes to change the direction of the chevron to point to the left (the direction the toolbar would collapse toward when clicked) while it's in the "wide" state.

As is often the case, a picture is worth a thousand words.

![improved-initiative-toolbar-toggle](https://user-images.githubusercontent.com/85644845/121450717-e3746980-c961-11eb-8143-734479cace26.gif)

I'm not 100% satisfied with _where_ I'm running this logic; the condition logic basically fires on all the buttons, which makes me want to cringe. But it's effective enough.

I did have an alternative approach using pure CSS, but this lets us leverage the utility already provided by FA out-of-the-box.