### PR TITLE
adds some subtle transition-based effects

### DIFF
--- a/lesscss/components/buttons.less
+++ b/lesscss/components/buttons.less
@@ -104,6 +104,7 @@
   text-align: center;
   text-decoration: none;
   border-radius: @border-radius;
+  transition: background-color @transition-hover;
 }
 
 .button,

--- a/lesscss/components/combatants.less
+++ b/lesscss/components/combatants.less
@@ -57,12 +57,21 @@
 }
 
 #tracker {
-  .combatant:hover {
-    background-color: @hover-white;
+  .combatant {
+    transition: box-shadow @transition-activation,
+      background-color @transition-hover,
+      border-color @transition-activation;
+
+    &:hover {
+      background-color: @hover-white;
+    }
   }
 
-  .combatant .combatant__hp:hover {
-    border-color: unset;
+  .combatant .combatant__hp {
+    transition: border @transition-hover;
+    &:hover {
+      border-color: unset;
+    }
   }
 }
 
@@ -140,10 +149,16 @@
   width: 1.4rem;
   border-left: @active-combatant-indicator-width solid transparent;
   cursor: grab;
+  opacity: .4;
+  transition: border-color @transition-automation, color @transition-automation, opacity @transition-hover;
 
   .active & {
     color: @primary-red;
     border-color: @primary-red;
+  }
+
+  &:hover {
+    opacity: 1;
   }
 }
 

--- a/lesscss/components/listing.less
+++ b/lesscss/components/listing.less
@@ -9,8 +9,11 @@
   background-color: @selected-light;
 }
 
-.listings span:hover {
-  background-color: @hover-white;
+.listings span {
+  transition: background-color @transition-hover;
+  &:hover {
+    background-color: @hover-white;
+  }
 }
 
 .c-listing {
@@ -23,7 +26,8 @@
   .c-listing-edit,
   .c-listing-move,
   .c-listing__counter {
-    display: none;
+    transition: opacity @transition-hover;
+    opacity: 0;
   }
 
   &:hover {
@@ -32,7 +36,7 @@
     .c-listing-delete,
     .c-listing-edit,
     .c-listing-move {
-      display: flex;
+      opacity: 1;
     }
   }
 }

--- a/lesscss/components/tabs.less
+++ b/lesscss/components/tabs.less
@@ -5,6 +5,7 @@
 
   .c-tab {
     background-color: @active-white;
+    transition: background-color @transition-hover;
     &:hover {
       background-color: @selected-light;
     }

--- a/lesscss/improved-initiative.less
+++ b/lesscss/improved-initiative.less
@@ -1,3 +1,4 @@
+
 @import url("https://fonts.googleapis.com/css?family=Roboto:400,400i,700,700i|Spectral+SC:400,400i,700,700i");
 @import "base/colors.less";
 @import "node_modules/@fortawesome/fontawesome-free/less/solid.less";
@@ -30,6 +31,15 @@
 @large: 1200px;
 @medium: 1000px;
 @small: 750px;
+
+
+// transition timings
+@transition-hover: .3s; // used for hover interactions
+@transition-activation: .4s; // used for click interactions
+@transition-automation: .5s; // used for slower, automated processes
+// note: other animations are powered by animxyz
+
+
 
 // elements
 


### PR DESCRIPTION
This includes a handful of CSS transition-powered animations, focused primarily on hover effects or visual indicators (e.g. current combatant, selected combatants, etc.), largely aiming to make the UI feel slightly more interactive.

They err on the side of subtlety so they're not distracting, but they still make things feel a bit smoother as you mouse around the UI. Eventually, I'd love to dive into transitions for all the React pop-ins, but I'm nowhere near experienced enough in React to pull that off.

It also sets three standard transition times to use based on _when_ they should be used, to take some of the guesswork out of future UI enhancements like this.

```less
// transition timings
@transition-hover: .3s; // used for hover interactions
@transition-activation: .4s; // used for click interactions
@transition-automation: .5s; // used for slower, automated processes
```