### PR TITLE
setting/enforcing standard spacing

### DIFF
--- a/client/Combatant/CombatantDetails.tsx
+++ b/client/Combatant/CombatantDetails.tsx
@@ -52,12 +52,13 @@ export function CombatantDetails(props: CombatantDetailsProps) {
       {tags.length > 0 && (
         <div className="c-combatant-details__tags">
           <span className="stat-label">Tags</span>{" "}
-          {tags.map((tag, index) => (
-            <React.Fragment key={index}>
-              <TagDetails tag={tag} />
-              {index !== tags.length - 1 && "; "}
-            </React.Fragment>
-          ))}
+          <span className="stat-value">
+            {tags.map((tag, index) => (
+              <React.Fragment key={index}>
+                <TagDetails tag={tag} />
+              </React.Fragment>
+            ))}
+          </span>
         </div>
       )}
       {props.displayMode !== "status-only" && (
@@ -82,11 +83,11 @@ function TagDetails(props: { tag: Tag }) {
   }
   if (props.tag.HasDuration) {
     return (
-      <>
+      <span className="stat-value__item">
         {props.tag.Text} ({durationRemaining} more rounds)
-      </>
+      </span>
     );
   }
 
-  return <>{props.tag.Text}</>;
+  return <span className="stat-value__item">{props.tag.Text}</span>;
 }

--- a/client/Commands/PromptQueue.test.ts
+++ b/client/Commands/PromptQueue.test.ts
@@ -10,6 +10,16 @@ function MockPrompt(): PromptProps<{}> {
   };
 }
 
+function MockPromptWithClass(): PromptProps<{}> {
+  return {
+    autoFocusSelector: "",
+    children: null,
+    initialValues: {},
+    onSubmit: jest.fn(() => true),
+    className: "custom-class"
+  };
+}
+
 describe("PromptQueue", () => {
   it("Can list prompts", () => {
     const promptQueue = new PromptQueue();
@@ -24,5 +34,12 @@ describe("PromptQueue", () => {
     const promptId = promptQueue.Add(prompt);
     promptQueue.Remove(promptId);
     expect(prompt.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("Recognizes custom class names", () => {
+    const promptQueue = new PromptQueue();
+    const prompt = MockPromptWithClass();
+    promptQueue.Add(prompt);
+    expect(promptQueue.GetPrompts()[0][0].className).toBe('custom-class');
   });
 });

--- a/client/Commands/PromptQueue.test.ts
+++ b/client/Commands/PromptQueue.test.ts
@@ -10,16 +10,6 @@ function MockPrompt(): PromptProps<{}> {
   };
 }
 
-function MockPromptWithClass(): PromptProps<{}> {
-  return {
-    autoFocusSelector: "",
-    children: null,
-    initialValues: {},
-    onSubmit: jest.fn(() => true),
-    className: "custom-class"
-  };
-}
-
 describe("PromptQueue", () => {
   it("Can list prompts", () => {
     const promptQueue = new PromptQueue();
@@ -34,12 +24,5 @@ describe("PromptQueue", () => {
     const promptId = promptQueue.Add(prompt);
     promptQueue.Remove(promptId);
     expect(prompt.onSubmit).not.toHaveBeenCalled();
-  });
-
-  it("Recognizes custom class names", () => {
-    const promptQueue = new PromptQueue();
-    const prompt = MockPromptWithClass();
-    promptQueue.Add(prompt);
-    expect(promptQueue.GetPrompts()[0][0].className).toBe('custom-class');
   });
 });

--- a/client/Components/StatBlock.tsx
+++ b/client/Components/StatBlock.tsx
@@ -73,7 +73,11 @@ export function StatBlockComponent(props: StatBlockProps) {
 
       <div className="speed">
         <span className="stat-label">Speed</span>
-        <span className="stat-value">{statBlock.Speed.join(", ")}</span>
+        <span className="stat-value">
+          {statBlock.Speed.map((speed, i) => (
+            <span className="stat-value__item">{speed}</span>
+          ))}
+        </span>
       </div>
 
       <div className="Abilities">

--- a/client/Components/StatBlock.tsx
+++ b/client/Components/StatBlock.tsx
@@ -57,7 +57,7 @@ export function StatBlockComponent(props: StatBlockProps) {
     <>
       <div className="AC">
         <span className="stat-label">Armor Class</span>
-        <span>{statBlock.AC.Value}</span>
+        <span className="stat-value">{statBlock.AC.Value}</span>
         <span className="notes">
           {textEnricher.EnrichText(statBlock.AC.Notes)}
         </span>
@@ -65,7 +65,7 @@ export function StatBlockComponent(props: StatBlockProps) {
 
       <div className="HP">
         <span className="stat-label">Hit Points</span>
-        <span>{statBlock.HP.Value}</span>
+        <span className="stat-value">{statBlock.HP.Value}</span>
         <span className="notes">
           {textEnricher.EnrichText(statBlock.HP.Notes)}
         </span>
@@ -73,7 +73,7 @@ export function StatBlockComponent(props: StatBlockProps) {
 
       <div className="speed">
         <span className="stat-label">Speed</span>
-        <span>{statBlock.Speed.join(", ")}</span>
+        <span className="stat-value">{statBlock.Speed.join(", ")}</span>
       </div>
 
       <div className="Abilities">
@@ -83,10 +83,10 @@ export function StatBlockComponent(props: StatBlockProps) {
             abilityScore
           );
           return (
-            <div key={abilityName}>
+            <div className="Ability" key={abilityName}>
               <div className="stat-label">{abilityName}</div>
-              <div className={"score " + abilityName}>{abilityScore}</div>
-              <div className={"modifier " + abilityName}>{abilityModifier}</div>
+              <span className={"score " + abilityName}>{abilityScore}</span>
+              <span className={"modifier " + abilityName}>{abilityModifier}</span>
             </div>
           );
         })}
@@ -101,7 +101,7 @@ export function StatBlockComponent(props: StatBlockProps) {
             <div key={modifierType.name} className={modifierType.name}>
               <span className="stat-label">{modifierType.name}</span>
               {modifierType.data.map((modifier, i) => (
-                <span key={i + modifier.Name}>
+                <span className="stat-value" key={i + modifier.Name}>
                   {modifier.Name}
                   {textEnricher.EnrichModifier(modifier.Modifier)}{" "}
                 </span>
@@ -116,7 +116,15 @@ export function StatBlockComponent(props: StatBlockProps) {
           .map(keywordSetType => (
             <div key={keywordSetType.name} className={keywordSetType.name}>
               <span className="stat-label">{keywordSetType.name}</span>
-              {keywordSetType.data.join(", ")}
+              <span className="stat-value">
+                <span className="stat-value__item">
+                  {keywordSetType.data.map((keyword, index) => {
+                    return (
+                      <span className="stat-value__item">{keyword}</span>
+                    )
+                  })}
+                </span>
+              </span>
             </div>
           ))}
       </div>
@@ -126,7 +134,7 @@ export function StatBlockComponent(props: StatBlockProps) {
           <span className="stat-label">
             {statBlock.Player == "player" ? "Level" : "Challenge"}
           </span>
-          <span>{statBlock.Challenge}</span>
+          <span className="stat-value">{statBlock.Challenge}</span>
         </div>
       )}
 

--- a/client/Library/Components/SpellDetails.tsx
+++ b/client/Library/Components/SpellDetails.tsx
@@ -23,19 +23,36 @@ export function SpellDetails(props: { Spell: Spell }) {
       <div className="spell-type">{getSpellType(props.Spell)}</div>
       <div className="spell-details">
         <div>
-          <label>Casting Time:</label> {props.Spell.CastingTime}
+          <label className="spell-label">Casting Time:</label>
+          <span className="spell-value">{props.Spell.CastingTime}</span>
         </div>
         <div>
-          <label>Range:</label> {props.Spell.Range}
+          <label className="spell-label">Range:</label>
+          <span className="spell-value">{props.Spell.Range}</span>
         </div>
         <div>
-          <label>Components:</label> {props.Spell.Components}
+          <label className="spell-label">Components:</label>
+          <span className="spell-value">
+            {props.Spell.Components.split(/\s*,\s*/).map((component, index) => {
+              return (
+                <span className="spell-value__item">{component}</span>
+              )
+            })}
+          </span>
         </div>
         <div>
-          <label>Duration:</label> {props.Spell.Duration}
+          <label className="spell-label">Duration:</label>
+          <span className="spell-value">{props.Spell.Duration}</span>
         </div>
         <div>
-          <label>Classes:</label> {props.Spell.Classes.join(", ")}
+          <label className="spell-label">Classes:</label>
+          <span className="spell-value">
+            {props.Spell.Classes.map((spellClass, index) => {
+              return (
+                <span className="spell-value__item">{spellClass}</span>
+              )
+            })}
+          </span>
         </div>
       </div>
       <div className="spell-description">

--- a/client/Prompts/PendingPrompts.tsx
+++ b/client/Prompts/PendingPrompts.tsx
@@ -6,11 +6,12 @@ export interface PromptProps<T extends object> {
   children: React.ReactChild;
   autoFocusSelector: string;
   initialValues: T;
+  className?: string;
 }
 
 class Prompt<T extends object> extends React.Component<
   PromptProps<T> & {
-    onCancel: () => void;
+    onCancel: () => void
   }
 > {
   private formElement: HTMLFormElement;
@@ -26,7 +27,7 @@ class Prompt<T extends object> extends React.Component<
         {(props: FormikProps<any>) => (
           <form
             ref={r => (this.formElement = r)}
-            className="prompt"
+            className={"prompt" + ((this.props.className) ? " " + this.props.className : "") }
             onSubmit={props.handleSubmit}
             onKeyUp={(e: React.KeyboardEvent<HTMLFormElement>) => {
               if (e.key == "Escape") {

--- a/client/Prompts/PendingPrompts.tsx
+++ b/client/Prompts/PendingPrompts.tsx
@@ -6,7 +6,6 @@ export interface PromptProps<T extends object> {
   children: React.ReactChild;
   autoFocusSelector: string;
   initialValues: T;
-  className?: string;
 }
 
 class Prompt<T extends object> extends React.Component<
@@ -27,7 +26,7 @@ class Prompt<T extends object> extends React.Component<
         {(props: FormikProps<any>) => (
           <form
             ref={r => (this.formElement = r)}
-            className={"prompt" + ((this.props.className) ? " " + this.props.className : "") }
+            className="prompt"
             onSubmit={props.handleSubmit}
             onKeyUp={(e: React.KeyboardEvent<HTMLFormElement>) => {
               if (e.key == "Escape") {

--- a/client/Prompts/SpellPrompt.tsx
+++ b/client/Prompts/SpellPrompt.tsx
@@ -19,6 +19,7 @@ export function SpellPrompt(
       </>
     ),
     initialValues: {},
+    className: "prompt-spell",
     onSubmit: () => true
   };
 }

--- a/client/Prompts/SpellPrompt.tsx
+++ b/client/Prompts/SpellPrompt.tsx
@@ -13,13 +13,12 @@ export function SpellPrompt(
   return {
     autoFocusSelector: "button",
     children: (
-      <>
+      <div className="prompt-spell">
         <SpellDetails Spell={spell} />
         <SubmitButton />
-      </>
+      </div>
     ),
     initialValues: {},
-    className: "prompt-spell",
     onSubmit: () => true
   };
 }

--- a/lesscss/components/spell.less
+++ b/lesscss/components/spell.less
@@ -24,6 +24,7 @@
     padding: @medium-spacer 0;
     border-top: 3px solid @primary-red;
     border-bottom: 3px solid @primary-red;
+    justify-content: space-between;
 
     p {
       flex-basis: 50%;
@@ -61,4 +62,11 @@
       margin-bottom: @small-spacer;
     }
   }
+
+  .spell-value + .spell-value, .spell-value__item + .spell-value__item {
+    &::before {
+      content: ", ";
+    }
+  }
+
 }

--- a/lesscss/components/spell.less
+++ b/lesscss/components/spell.less
@@ -56,5 +56,9 @@
   .spell-description {
     margin: @large-spacer 0 @medium-spacer;
     padding: 0 !important;
+
+    p:not(:last-child), li:not(:last-child) {
+      margin-bottom: @small-spacer;
+    }
   }
 }

--- a/lesscss/components/spell.less
+++ b/lesscss/components/spell.less
@@ -7,11 +7,15 @@
 }
 
 // some overrides to allow spell details to go full width
-.prompt.prompt-spell {
+.prompt-spell {
+  flex-direction: inherit;
+  align-items: flex-start;
+
   > .c-button {
     transform: translateX(-100%);
     margin-left: 0;
   }
+
   .spell { min-width: 100%; }
 }
 

--- a/lesscss/components/spell.less
+++ b/lesscss/components/spell.less
@@ -6,6 +6,15 @@
   flex-shrink: 1;
 }
 
+// some overrides to allow spell details to go full width
+.prompt.prompt-spell {
+  > .c-button {
+    transform: translateX(-100%);
+    margin-left: 0;
+  }
+  .spell { min-width: 100%; }
+}
+
 .spell {
   flex-grow: 1;
   flex-flow: row;

--- a/lesscss/components/statblock.less
+++ b/lesscss/components/statblock.less
@@ -116,8 +116,8 @@
   }
 
   .Abilities {
-    justify-content: space-around;
-    margin: @medium-spacer;
+    justify-content: space-between;
+    margin: @medium-spacer @large-spacer @medium-spacer 0;
 
     div {
       flex-direction: row;

--- a/lesscss/components/statblock.less
+++ b/lesscss/components/statblock.less
@@ -31,7 +31,15 @@
 .c-combatant-details__tags {
   flex-direction: row;
   margin-top: @extra-small-spacer;
+
+  .stat-label {
+  }
+  .stat-value {
+    display: block;
+    flex: 1;
+  }
 }
+
 
 .combatant-details__header {
   display: flex;
@@ -83,6 +91,12 @@
   margin: 0 @small-spacer 0 0;
   color: @primary-red;
 }
+.stat-value + .stat-value, .stat-value__item + .stat-value__item {
+  &::before {
+    content: ", ";
+  }
+}
+
 
 .c-statblock {
   display: block;
@@ -113,11 +127,6 @@
   }
   .stat-value + .notes {
     margin-left: @small-spacer;
-  }
-  .stat-value + .stat-value, .stat-value__item + .stat-value__item {
-    &::before {
-      content: ", ";
-    }
   }
 
   .power-content {

--- a/lesscss/components/statblock.less
+++ b/lesscss/components/statblock.less
@@ -4,7 +4,7 @@
 
   .c-statblock-header__portrait {
     max-height: 4rem;
-    padding: @small-spacer;
+    padding: 0 @small-spacer @small-spacer 0;
     cursor: zoom-in;
   }
 
@@ -30,6 +30,7 @@
 .c-combatant-details__hp,
 .c-combatant-details__tags {
   flex-direction: row;
+  margin-top: @extra-small-spacer;
 }
 
 .combatant-details__header {
@@ -79,7 +80,7 @@
 
 .stat-label {
   font-weight: bold;
-  margin: 0 @extra-small-spacer @extra-small-spacer 0;
+  margin: 0 @small-spacer 0 0;
   color: @primary-red;
 }
 
@@ -97,6 +98,10 @@
     align-items: center;
   }
 
+  p:not(:last-child), li:not(:last-child) {
+    margin-bottom: @extra-small-spacer;
+  }
+
   pre {
     white-space: pre-wrap;
   }
@@ -105,9 +110,13 @@
     flex-direction: row;
     flex-wrap: wrap;
     max-height: none;
-
-    span {
-      padding-right: @extra-small-spacer;
+  }
+  .stat-value + .notes {
+    margin-left: @small-spacer;
+  }
+  .stat-value + .stat-value, .stat-value__item + .stat-value__item {
+    &::before {
+      content: ", ";
     }
   }
 
@@ -115,45 +124,50 @@
     white-space: pre-line;
   }
 
+  .AC, .HP {
+    margin-bottom: @extra-small-spacer;
+  }
+
   .Abilities {
     justify-content: space-between;
-    margin: @medium-spacer @large-spacer @medium-spacer 0;
+    margin: @medium-spacer 0;
+    flex-direction: row;
+    justify-content: center;
+    flex-wrap: wrap;
 
-    div {
+    .Ability {
+      flex-basis: calc(100% / 6);
       flex-direction: row;
-      justify-content: center;
       flex-wrap: wrap;
-      width: calc(80% / 6);
-
-      .stat-label {
-        display: inline-block;
-        width: 100%;
-        text-align: center;
-      }
-
-      .modifier,
-      .score {
-        display: inline-block;
-        flex: 1;
-        font-size: @font-size-small;
-        text-align: center;
-      }
-
-      .modifier {
-        &:before {
-          content: "(";
-        }
-
-        &:after {
-          content: ")";
-        }
-      }
+      justify-content: center;
     }
 
     .stat-label {
+      display: block;
+      text-align: center;
+      margin-right: 0;
+      flex-basis: 100%;
       margin-bottom: @extra-small-spacer;
       font-size: @font-size-small;
       text-transform: uppercase;
+    }
+
+    .modifier,
+    .score {
+      display: inline-block;
+      font-size: @font-size-small;
+      text-align: center;
+    }
+
+    .modifier {
+      margin-left: @small-spacer;
+      &:before {
+        content: "(";
+      }
+
+      &:after {
+        content: ")";
+      }
     }
   }
 
@@ -170,12 +184,12 @@
   .Skills,
   .Saves {
     .rollable {
-      margin: 0 @small-spacer;
-
-      &:after {
-        content: ";";
-      }
+      margin-left: @small-spacer;
     }
+  }
+
+  .Skills, .Saves, .keyword-sets > div {
+    margin-bottom: @small-spacer;
   }
 
   .Actions,
@@ -187,7 +201,7 @@
     div {
       flex-direction: column;
       display: inline;
-      margin: 0 0 @medium-spacer 0;
+      margin: 0 0 @large-spacer 0;
 
       &:last-of-type {
         margin-bottom: 0;

--- a/lesscss/components/statblock.less
+++ b/lesscss/components/statblock.less
@@ -189,6 +189,10 @@
       display: inline;
       margin: 0 0 @medium-spacer 0;
 
+      &:last-of-type {
+        margin-bottom: 0;
+      }
+
       > .stat-label {
         font-style: italic;
         color: @primary-black;

--- a/lesscss/components/statblock.less
+++ b/lesscss/components/statblock.less
@@ -146,9 +146,8 @@
 
     .Ability {
       flex-basis: calc(100% / 6);
-      flex-direction: row;
-      flex-wrap: wrap;
-      justify-content: center;
+      display: block;
+      text-align: center;
     }
 
     .stat-label {
@@ -169,8 +168,8 @@
     }
 
     .modifier {
-      margin-left: @small-spacer;
       &:before {
+        margin-left: @extra-small-spacer;
         content: "(";
       }
 


### PR DESCRIPTION
This is a mostly superficial change, but I had to get into some of the logic to provide a means to execute some items.

Essentially, this is a clean-up and standardization of various margins / spacing surrounding content/stats. It's mostly focused on statblocks...

![image](https://user-images.githubusercontent.com/85644845/121581407-67c2fd00-c9f3-11eb-9972-c24ec7a27399.png)

...but there are a few simple touches on spells as well.

![image](https://user-images.githubusercontent.com/85644845/121581531-8a551600-c9f3-11eb-832b-09089f7a16b9.png)


Goals here include:

* standardized margins between sections / headers / etc.
* small margin between paragraphs and list items to improve legibility
* standardizes small, delimited selections (e.g. combatant tags, languages, speeds, skills, saves; spell components, classes) to use CSS rather than logic to render commas, which will allow for future visual enhancements, since each is tagged separately.
* fix a frequent issue I run into where my statblock's scrollbar covers part of the Charisma score
* use the full width of the prompt box for the spells (by passing a custom CSS class to render in the parent `<form/>`)