### PR TITLE
Fix xml trait importer bug

### DIFF
--- a/client/Importers/Importer.ts
+++ b/client/Importers/Importer.ts
@@ -53,7 +53,7 @@ export class Importer {
   public getPowers(selector: string) {
     return _.map(this.domElement.querySelectorAll(selector), p => ({
       Name: p.querySelector<Element>("name")?.innerHTML,
-      Content: p.querySelector<Element>("text")?.innerHTML,
+      Content: Array.from(p.querySelectorAll<Element>("text")).map(pp => pp?.innerHTML).join("\n"),
       Usage: ""
     }));
   }


### PR DESCRIPTION
Fixes a bug where if a monster trait or action block had multiple lines of text it would only take the first line.

Let me know if there is a better way to do this. I'm not used to javascript.