### PR TITLE
Switching the order of the calls to saveListing and DeleteListing when overwriting an existing listing

### DIFF
--- a/client/Library/useLibrary.ts
+++ b/client/Library/useLibrary.ts
@@ -124,13 +124,11 @@ export function useLibrary<T extends Listable>(
         "localAsync"
       );
 
-      const savedListing = await saveListing(listing, newListable);
-
       for (const listingToOverwrite of listingsToOverwrite) {
         await DeleteListing(listingToOverwrite.Meta().Id);
       }
 
-      return savedListing;
+      return await saveListing(listing, newListable);
     },
     [listings]
   );


### PR DESCRIPTION
This should fix #595. It appears that the issue was that the new listing would be created, then the listing to overwrite would be deleted. Since the records have the same `Id` (since it's overwriting), the new record would get deleted immediately after it's created.

I will note that tests are failing, but that seems to be a [pre-existing issue](https://github.com/cynicaloptimist/improved-initiative/actions/runs/4837389815/jobs/8621178696).