### PR TITLE
Pre-fill Save Encounter form

### DIFF
--- a/client/AutosavedEncounterTest.test.tsx
+++ b/client/AutosavedEncounterTest.test.tsx
@@ -47,6 +47,10 @@ describe("Autosaved Encounters", () => {
       RoundCounter: 0,
       ElapsedSeconds: 0,
       BackgroundImageUrl: null,
+      SaveEncounterDefaults: {
+        Name: "Goblin Ambush",
+        Path: "Chapter 1"
+      },
       Combatants: [CombatantStateWithName("1"), CombatantStateWithName("2")]
     };
     LegacySynchronousLocalStore.Save(
@@ -65,6 +69,41 @@ describe("Autosaved Encounters", () => {
     viewModel.LoadAutoSavedEncounterIfAvailable();
     const combatants = viewModel.Encounter.Combatants();
     expect(combatants.map(c => c.DisplayName())).toEqual(["1", "2"]);
+    expect(viewModel.Encounter.SaveEncounterDefaults()).toEqual({
+      Name: "Goblin Ambush",
+      Path: "Chapter 1"
+    });
+  });
+
+  it("autosaves save defaults", () => {
+    InitializeTestSettings({
+      PreloadedContent: {
+        BasicRules: false,
+        Open5eContent: false
+      }
+    });
+    const viewModel = new TrackerViewModel(io());
+    const libraries = renderHook(() =>
+      useLibraries(CurrentSettings(), MockAccountClient(), () => {})
+    );
+    viewModel.SetLibraries(libraries.result.current);
+    viewModel.LoadAutoSavedEncounterIfAvailable();
+
+    viewModel.Encounter.SaveEncounterDefaults({
+      Name: "Goblin Ambush",
+      Path: "Chapter 1"
+    });
+
+    const autosavedEncounter = LegacySynchronousLocalStore.Load<
+      EncounterState<CombatantState>
+    >(
+      LegacySynchronousLocalStore.AutoSavedEncounters,
+      LegacySynchronousLocalStore.DefaultSavedEncounterId
+    );
+    expect(autosavedEncounter.SaveEncounterDefaults).toEqual({
+      Name: "Goblin Ambush",
+      Path: "Chapter 1"
+    });
   });
 
   it.todo("loads persistent characters from account");

--- a/client/Commands/EncounterCommander.test.ts
+++ b/client/Commands/EncounterCommander.test.ts
@@ -1,4 +1,5 @@
 import { PersistentCharacter } from "../../common/PersistentCharacter";
+import { SavedEncounter } from "../../common/SavedEncounter";
 import { StatBlock } from "../../common/StatBlock";
 import { Encounter } from "../Encounter/Encounter";
 import { InitializeTestSettings } from "../test/InitializeTestSettings";
@@ -43,31 +44,54 @@ describe("EncounterCommander", () => {
     encounter.ClearEncounter();
   });
 
+  function buildSavedEncounter(Name: string, Path: string): SavedEncounter {
+    return {
+      ...SavedEncounter.Default(),
+      Name,
+      Path,
+      Combatants: []
+    };
+  }
+
+  function getSavePrompt() {
+    trackerViewModel.LibrariesCommander.SaveEncounter();
+    const prompts = trackerViewModel.PromptQueue.GetPrompts();
+    return prompts[prompts.length - 1][0];
+  }
+
+  function submitSaveEncounter(Name: string, Path: string) {
+    trackerViewModel.Libraries.Encounters.SaveNewListing = jest.fn(
+      async () => null
+    );
+    const prompt = getSavePrompt();
+    prompt.onSubmit({ ...prompt.initialValues, Name, Path });
+  }
+
   test("Cannot start an empty encounter.", () => {
     encounterCommander.StartEncounter();
     expect(encounter.EncounterFlow.State()).toBe("inactive");
     expect(encounter.Combatants().length).toBe(0);
-    expect(!encounter.EncounterFlow.ActiveCombatant());
+    expect(encounter.EncounterFlow.ActiveCombatant()).toBeFalsy();
   });
 
   test("Click Next Turn with no combatants.", () => {
     encounter.EncounterFlow.NextTurn = jest.fn(
       encounter.EncounterFlow.NextTurn
     );
-    expect(!encounter.EncounterFlow.ActiveCombatant());
+    expect(encounter.EncounterFlow.ActiveCombatant()).toBeFalsy();
     encounterCommander.NextTurn();
-    expect(encounter.EncounterFlow.CombatTimer.ElapsedRounds() == 1);
-    expect(encounter.EncounterFlow.NextTurn).not.toBeCalled();
+    expect(encounter.EncounterFlow.CombatTimer.ElapsedRounds()).toBe(0);
+    expect(encounter.EncounterFlow.NextTurn).not.toHaveBeenCalled();
   });
 
   test("Calling Next Turn should start an inactive encounter.", () => {
     const startEncounter = (encounterCommander.StartEncounter = jest.fn());
 
     encounter.AddCombatantFromStatBlock(StatBlock.Default());
-    expect(!encounter.EncounterFlow.ActiveCombatant());
+    expect(encounter.EncounterFlow.ActiveCombatant()).toBeFalsy();
     encounterCommander.NextTurn();
 
-    expect(startEncounter).toBeCalled();
+    expect(startEncounter).toHaveBeenCalled();
   });
 
   test("CleanEncounter", async () => {
@@ -89,6 +113,114 @@ describe("EncounterCommander", () => {
     expect(encounter.ObservableEncounterState().Combatants.length).toBe(1);
   });
 
+  test("Save Encounter starts with empty defaults", () => {
+    expect(getSavePrompt().initialValues).toMatchObject({
+      Name: "",
+      Path: ""
+    });
+  });
+
+  test("Save Encounter keeps an empty folder as a default", () => {
+    submitSaveEncounter("New Encounter", "");
+
+    expect(encounter.SaveEncounterDefaults()).toEqual({
+      Name: "New Encounter",
+      Path: ""
+    });
+    expect(getSavePrompt().initialValues).toMatchObject({
+      Name: "New Encounter",
+      Path: ""
+    });
+  });
+
+  test("opening a saved encounter uses its name and folder as save defaults until cleaning", async () => {
+    const savedEncounter = buildSavedEncounter("Goblin Ambush", "Chapter 1");
+
+    await encounterCommander.LoadSavedEncounter(savedEncounter);
+
+    expect(encounter.SaveEncounterDefaults()).toEqual({
+      Name: "Goblin Ambush",
+      Path: "Chapter 1"
+    });
+
+    expect(getSavePrompt().initialValues).toMatchObject({
+      Name: "Goblin Ambush",
+      Path: "Chapter 1"
+    });
+
+    encounterCommander.CleanEncounter();
+    expect(encounter.SaveEncounterDefaults()).toBeNull();
+
+    expect(getSavePrompt().initialValues).toMatchObject({ Name: "", Path: "" });
+
+    submitSaveEncounter("New Encounter", "New Folder");
+
+    expect(getSavePrompt().initialValues).toMatchObject({
+      Name: "New Encounter",
+      Path: "New Folder"
+    });
+  });
+
+  test("opening another saved encounter replaces the save defaults", async () => {
+    await encounterCommander.LoadSavedEncounter(
+      buildSavedEncounter("Goblin Ambush", "Chapter 1")
+    );
+    await encounterCommander.LoadSavedEncounter(
+      buildSavedEncounter("Dragon Attack", "Chapter 2")
+    );
+
+    expect(getSavePrompt().initialValues).toMatchObject({
+      Name: "Dragon Attack",
+      Path: "Chapter 2"
+    });
+  });
+
+  test("saving an opened encounter under a new name replaces the save defaults", async () => {
+    await encounterCommander.LoadSavedEncounter(
+      buildSavedEncounter("Goblin Ambush", "Chapter 1")
+    );
+
+    submitSaveEncounter("Dragon Attack", "Chapter 2");
+
+    expect(getSavePrompt().initialValues).toMatchObject({
+      Name: "Dragon Attack",
+      Path: "Chapter 2"
+    });
+  });
+
+  test("cancelling Save Encounter preserves its current defaults", async () => {
+    await encounterCommander.LoadSavedEncounter(
+      buildSavedEncounter("Goblin Ambush", "Chapter 1")
+    );
+
+    getSavePrompt();
+    const prompts = trackerViewModel.PromptQueue.GetPrompts();
+    trackerViewModel.PromptQueue.Remove(prompts[prompts.length - 1][1]);
+
+    expect(getSavePrompt().initialValues).toMatchObject({
+      Name: "Goblin Ambush",
+      Path: "Chapter 1"
+    });
+  });
+
+  test("save defaults update before persistence completes", () => {
+    trackerViewModel.Libraries.Encounters.SaveNewListing = jest.fn(
+      () => new Promise(() => {})
+    );
+    const prompt = getSavePrompt();
+
+    prompt.onSubmit({
+      ...prompt.initialValues,
+      Name: "Optimistic Save",
+      Path: "Chapter 1"
+    });
+
+    expect(encounter.SaveEncounterDefaults()).toEqual({
+      Name: "Optimistic Save",
+      Path: "Chapter 1"
+    });
+  });
+
   test("ClearEncounter", async () => {
     const persistentCharacter = PersistentCharacter.Initialize({
       ...StatBlock.Default(),
@@ -101,9 +233,14 @@ describe("EncounterCommander", () => {
       false
     );
 
+    encounter.SaveEncounterDefaults({
+      Name: "Goblin Ambush",
+      Path: "Chapter 1"
+    });
     expect(encounter.Combatants().length).toBe(2);
     encounterCommander.ClearEncounter();
     expect(encounter.Combatants().length).toBe(0);
+    expect(encounter.SaveEncounterDefaults()).toBeNull();
   });
 
   test("Restore Player Character HP", async () => {

--- a/client/Commands/EncounterCommander.ts
+++ b/client/Commands/EncounterCommander.ts
@@ -195,6 +195,7 @@ export class EncounterCommander {
         this.tracker.Encounter.RemoveCombatant(vm.Combatant)
       );
       this.tracker.Encounter.CombatantCountsByName({});
+      this.tracker.Encounter.SaveEncounterDefaults(null);
       Metrics.TrackEvent(Metrics.Event.EncounterCleaned);
     }
 
@@ -214,6 +215,10 @@ export class EncounterCommander {
     legacySavedEncounter: Record<string, any>
   ): Promise<void> => {
     const savedEncounter = UpdateLegacySavedEncounter(legacySavedEncounter);
+    this.tracker.Encounter.SaveEncounterDefaults({
+      Name: savedEncounter.Name,
+      Path: savedEncounter.Path
+    });
 
     const nonCharacterCombatants = savedEncounter.Combatants.filter(
       c => !c.PersistentCharacterId

--- a/client/Commands/LibrariesCommander.ts
+++ b/client/Commands/LibrariesCommander.ts
@@ -267,12 +267,21 @@ export class LibrariesCommander {
   };
 
   public SaveEncounter = (): void => {
+    const saveEncounterDefaults = this.tracker.Encounter.SaveEncounterDefaults();
+    const saveEncounterToLibrary = (newEncounter: SavedEncounter) => {
+      this.tracker.Encounter.SaveEncounterDefaults({
+        Name: newEncounter.Name,
+        Path: newEncounter.Path
+      });
+      return this.libraries.Encounters.SaveNewListing(newEncounter);
+    };
     const prompt = SaveEncounterPrompt(
       this.tracker.Encounter.FullEncounterState(),
       this.tracker.Encounter.TemporaryBackgroundImageUrl(),
-      this.libraries.Encounters.SaveNewListing,
+      saveEncounterToLibrary,
       this.tracker.EventLog.AddEvent,
-      _.uniq(this.libraries.Encounters.GetAllListings().map(e => e.Meta().Path))
+      _.uniq(this.libraries.Encounters.GetAllListings().map(e => e.Meta().Path)),
+      saveEncounterDefaults
     );
     this.tracker.PromptQueue.Add(prompt);
   };

--- a/client/Encounter/Encounter.ts
+++ b/client/Encounter/Encounter.ts
@@ -7,7 +7,10 @@ import * as _ from "lodash";
 
 import { CombatStats } from "../../common/CombatStats";
 import { CombatantState } from "../../common/CombatantState";
-import { EncounterState } from "../../common/EncounterState";
+import {
+  EncounterSaveDefaults,
+  EncounterState
+} from "../../common/EncounterState";
 import { PersistentCharacter } from "../../common/PersistentCharacter";
 import { PlayerViewCombatantState } from "../../common/PlayerViewCombatantState";
 import { StatBlock } from "../../common/StatBlock";
@@ -36,6 +39,9 @@ import { ConvertStringsToNumbersWhereNeeded } from "../StatBlockEditor/ConvertSt
 
 export class Encounter {
   public TemporaryBackgroundImageUrl = ko.observable<string>(null);
+  public SaveEncounterDefaults = ko.observable<EncounterSaveDefaults | null>(
+    null
+  );
 
   private lastVisibleActiveCombatantId: string | null = null;
 
@@ -381,7 +387,8 @@ export class Encounter {
         Combatants: this.combatants()
           .filter(c => !c.IsPendingRemoval())
           .map<CombatantState>(c => c.GetState()),
-        BackgroundImageUrl: this.TemporaryBackgroundImageUrl()
+        BackgroundImageUrl: this.TemporaryBackgroundImageUrl(),
+        SaveEncounterDefaults: this.SaveEncounterDefaults()
       };
     }
   );
@@ -465,12 +472,14 @@ export class Encounter {
       encounterState.ElapsedSeconds || 0
     );
     this.TemporaryBackgroundImageUrl(encounterState.BackgroundImageUrl || null);
+    this.SaveEncounterDefaults(encounterState.SaveEncounterDefaults || null);
   };
 
   public ClearEncounter = () => {
     this.combatants([]);
     this.CombatantCountsByName({});
     this.EncounterFlow.EndEncounter();
+    this.SaveEncounterDefaults(null);
   };
 
   private getPlayerViewActiveCombatantId() {

--- a/client/Encounter/LegacyEncounter.test.ts
+++ b/client/Encounter/LegacyEncounter.test.ts
@@ -86,6 +86,7 @@ describe("UpdateLegacyEncounterState", () => {
     const updatedEncounter = UpdateLegacyEncounterState(v1Encounter);
     expect(updatedEncounter.Combatants).toHaveLength(1);
     expect(updatedEncounter.RoundCounter).toEqual(0);
+    expect(updatedEncounter.SaveEncounterDefaults).toBeNull();
 
     const updatedCombatant = updatedEncounter.Combatants[0];
 

--- a/client/Encounter/UpdateLegacySavedEncounter.ts
+++ b/client/Encounter/UpdateLegacySavedEncounter.ts
@@ -75,7 +75,8 @@ export function UpdateLegacyEncounterState(
     RoundCounter: encounterState.RoundCounter || 0,
     ElapsedSeconds: encounterState.ElapsedSeconds || 0,
     ActiveCombatantId: null,
-    BackgroundImageUrl: encounterState.BackgroundImageUrl
+    BackgroundImageUrl: encounterState.BackgroundImageUrl,
+    SaveEncounterDefaults: encounterState.SaveEncounterDefaults || null
   };
 
   updatedEncounter.Combatants.forEach(updateLegacySavedCombatant);

--- a/client/Library/SavedEncounterLibrary.test.tsx
+++ b/client/Library/SavedEncounterLibrary.test.tsx
@@ -1,0 +1,91 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import { SavedEncounter } from "../../common/SavedEncounter";
+import { Store } from "../Utility/Store";
+import { useLibrary } from "./useLibrary";
+
+function buildSavedEncounter(
+  Id: string,
+  Name: string,
+  Path: string
+): SavedEncounter {
+  return {
+    ...SavedEncounter.Default(),
+    Id,
+    Name,
+    Path
+  };
+}
+
+describe("Saved Encounter Library", () => {
+  beforeEach(() => {
+    jest.spyOn(Store, "LoadAllAndUpdateIds").mockResolvedValue([]);
+    jest.spyOn(Store, "Save").mockResolvedValue();
+    jest.spyOn(Store, "Delete").mockResolvedValue();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function renderSavedEncounterLibrary() {
+    return renderHook(() =>
+      useLibrary(Store.SavedEncounters, "encounters", {
+        createEmptyListing: SavedEncounter.Default,
+        accountSave: () => undefined,
+        accountDelete: () => undefined,
+        getSearchHint: SavedEncounter.GetSearchHint,
+        getFilterDimensions: () => ({})
+      })
+    );
+  }
+
+  test("saving with the same name and folder replaces a local encounter", async () => {
+    const { result } = renderSavedEncounterLibrary();
+    const original = buildSavedEncounter(
+      "original",
+      "Goblin Ambush",
+      "Chapter 1"
+    );
+    const replacement = buildSavedEncounter(
+      "replacement",
+      "Goblin Ambush",
+      "Chapter 1"
+    );
+
+    await act(async () => {
+      await result.current.SaveNewListing(original);
+    });
+    await act(async () => {
+      await result.current.SaveNewListing(replacement);
+    });
+
+    expect(result.current.GetAllListings()).toHaveLength(1);
+    expect(Store.Delete).toHaveBeenCalledWith(
+      Store.SavedEncounters,
+      "original"
+    );
+    const savedEncounter = await result.current
+      .GetAllListings()[0]
+      .GetWithTemplate(SavedEncounter.Default());
+    expect(savedEncounter).toMatchObject(replacement);
+  });
+
+  test("saving the same name in different folders keeps separate encounters", async () => {
+    const { result } = renderSavedEncounterLibrary();
+
+    await act(async () => {
+      await result.current.SaveNewListing(
+        buildSavedEncounter("chapter-one", "Goblin Ambush", "Chapter 1")
+      );
+      await result.current.SaveNewListing(
+        buildSavedEncounter("chapter-two", "Goblin Ambush", "Chapter 2")
+      );
+    });
+
+    expect(result.current.GetAllListings()).toHaveLength(2);
+    expect(result.current.GetAllListings().map(l => l.Meta().Path)).toEqual([
+      "Chapter 1",
+      "Chapter 2"
+    ]);
+  });
+});

--- a/client/Prompts/SaveEncounterPrompt.tsx
+++ b/client/Prompts/SaveEncounterPrompt.tsx
@@ -1,7 +1,10 @@
 import { Field, FieldArray, FieldProps } from "formik";
 import * as React from "react";
 import { CombatantState } from "../../common/CombatantState";
-import { EncounterState } from "../../common/EncounterState";
+import {
+  EncounterSaveDefaults,
+  EncounterState
+} from "../../common/EncounterState";
 import { SavedEncounter } from "../../common/SavedEncounter";
 import { probablyUniqueString } from "../../common/Toolbox";
 import { AccountClient } from "../Account/AccountClient";
@@ -112,12 +115,13 @@ export function SaveEncounterPrompt(
     newEncounter: SavedEncounter
   ) => Promise<Listing<SavedEncounter>>,
   logEvent: typeof EventLog.prototype.AddEvent,
-  autocompletePaths: string[]
+  autocompletePaths: string[],
+  defaultEncounter?: EncounterSaveDefaults
 ): PromptProps<SaveEncounterModel> {
   return {
     initialValues: {
-      Name: "",
-      Path: "",
+      Name: defaultEncounter?.Name || "",
+      Path: defaultEncounter?.Path || "",
       BackgroundImageUrl: backgroundImageUrl,
       NonCharacterCombatants: encounterState.Combatants.filter(
         c => c.PersistentCharacterId == null

--- a/common/EncounterState.ts
+++ b/common/EncounterState.ts
@@ -1,8 +1,14 @@
+export interface EncounterSaveDefaults {
+  Name: string;
+  Path: string;
+}
+
 export interface EncounterState<T> {
   ActiveCombatantId: string | null;
   RoundCounter?: number;
   ElapsedSeconds?: number;
   BackgroundImageUrl?: string;
+  SaveEncounterDefaults?: EncounterSaveDefaults | null;
   Combatants: T[];
 }
 
@@ -12,6 +18,7 @@ export namespace EncounterState {
       ActiveCombatantId: null,
       RoundCounter: 0,
       ElapsedSeconds: 0,
+      SaveEncounterDefaults: null,
       Combatants: []
     };
   }


### PR DESCRIPTION
Hi! I was prepping my encounters and noticed I would love to have this feature, so went ahead with a Pull Request 😊 

## Feautre description

Basically, when users need to edit saved encounters (e.g. maybe add or remove some monsters), they currently need to input name and folder every time to save changes to the existing encounter.

Assuming editing is an often use-case (definitely is for me), this feature pre-fills name and folder using the metadata of the last opened encounter.

So you open your existing encounter, make the change, click Save - the form appears already pre-filled with the data of the encounter you were editing - click the "Submit" checkmark, and it's done. 

I realise this is a breaking behaviour, so if you wish, I could (in this PR or as a follow-up):

* add a setting to control this behaviour, with the default one being the current one
* and/or hoist the folder name input to the "compact" form view, so it's always obvious and you don't need to click the "Wrench" icon to access/see that value

## Testing

Here is the QA checklist I ran. Not all cases required new test code, some were covered by existing tests :) 

| # | Short name | Description | Unit tested | Manually tested |
| ---: | --- | --- | :---: | :---: |
| 1 | Fresh session | Without opening or saving an encounter, Save Current Encounter starts with an empty name and folder. | [x] | [x] |
| 2 | First save | Saving a fresh encounter stores its submitted name and folder as the defaults for the next save. | [x] | [x] |
| 3 | First save, no folder | Saving with an empty folder keeps the name and an empty folder as the next defaults. | [x] | [x] |
| 4 | Open saved encounter | Opening a saved encounter pre-populates the save form with that encounter's name and folder. | [x] | [x] |
| 5 | Open different encounter | Opening encounter A and then B makes B's name and folder the defaults. | [x] | [x] |
| 6 | Save as new copy | Opening A and saving as B updates subsequent defaults to B and creates a separate saved encounter. | [x] | [x] |
| 7 | Cancel save | Editing the save form and cancelling leaves the previous name and folder defaults unchanged. | [x] | [x] |
| 8 | Clean or clear | Confirming Clean Encounter or Clear Encounter clears the stored name and folder defaults. | [x] | [x] |
| 9 | Save opened encounter | Saving an opened encounter unchanged updates that same saved item instead of creating a duplicate. | [x] | [x] |
| 10 | Reload | Name and folder defaults survive autosave and app reload. | [x] | [x] |
| 11 | Rename or move | **Deferred for a follow-up PR**: behavior after renaming or moving an already-open saved encounter is not yet defined. | [ ] | [ ] |
| 12 | Save failure | Defaults update optimistically when the form is submitted; persistence failures do not roll them back. | [x] | [ ] |

Happy to talk about this or make any changes to the PR!

Cheers!