### PR TITLE
Add backspace alias for del key for MacBooks

### DIFF
--- a/client/Settings/Settings.test.ts
+++ b/client/Settings/Settings.test.ts
@@ -1,10 +1,49 @@
+import * as Mousetrap from "mousetrap";
+
 import { getDefaultSettings, Settings } from "../../common/Settings";
+import { Command } from "../Commands/Command";
 import { LegacySynchronousLocalStore } from "../Utility/LegacySynchronousLocalStore";
-import { CurrentSettings, InitializeSettings } from "./Settings";
+import {
+  CurrentSettings,
+  GetAppleBackspaceAlias,
+  InitializeSettings,
+  IsAppleBackspacePlatform,
+  SubscribeCommandsToSettingsChanges
+} from "./Settings";
+
+const backspaceKeyCode = 8;
+const deleteKeyCode = 46;
+
+function setPlatform(platform: string) {
+  Object.defineProperty(navigator, "platform", {
+    configurable: true,
+    value: platform
+  });
+}
+
+function dispatchKeyDown(which: number) {
+  const event = new KeyboardEvent("keydown", { bubbles: true });
+  Object.defineProperty(event, "which", { value: which });
+  document.dispatchEvent(event);
+}
+
+function MakeRemoveCommand(actionBinding: jest.Mock) {
+  return new Command({
+    id: "remove",
+    description: "Remove",
+    actionBinding,
+    fontAwesomeIcon: "times"
+  });
+}
 
 describe("Settings", () => {
   beforeEach(() => {
     localStorage.clear();
+  });
+
+  afterEach(() => {
+    Mousetrap.reset();
+    delete (navigator as { platform?: string }).platform;
   });
 
   test("Initializes to default settings", () => {
@@ -20,5 +59,58 @@ describe("Settings", () => {
         "Settings"
       )
     ).toEqual(getDefaultSettings());
+  });
+
+  test("Identifies platforms that use Backspace for Delete shortcuts", () => {
+    expect(IsAppleBackspacePlatform("MacIntel")).toBe(true);
+    expect(IsAppleBackspacePlatform("Macintosh")).toBe(true);
+    expect(IsAppleBackspacePlatform("iPad")).toBe(true);
+  });
+
+  test(
+    "Does not identify unrelated platforms as Apple Backspace platforms",
+    () => {
+      expect(IsAppleBackspacePlatform("Win32")).toBe(false);
+      expect(IsAppleBackspacePlatform("iPhone")).toBe(false);
+    }
+  );
+
+  test("Aliases standalone Delete keys without matching substrings", () => {
+    expect(GetAppleBackspaceAlias("del")).toEqual("backspace");
+    expect(GetAppleBackspaceAlias("alt+shift+del")).toEqual(
+      "alt+shift+backspace"
+    );
+    expect(GetAppleBackspaceAlias("del del")).toEqual(
+      "backspace backspace"
+    );
+    expect(GetAppleBackspaceAlias("delete")).toBeNull();
+    expect(GetAppleBackspaceAlias("alt+o")).toBeNull();
+  });
+
+  test("Runs Delete shortcuts with Backspace on Mac", () => {
+    CurrentSettings(getDefaultSettings());
+    setPlatform("MacIntel");
+    const actionBinding = jest.fn();
+
+    SubscribeCommandsToSettingsChanges([MakeRemoveCommand(actionBinding)]);
+    dispatchKeyDown(backspaceKeyCode);
+
+    expect(actionBinding).toHaveBeenCalledTimes(1);
+
+    dispatchKeyDown(deleteKeyCode);
+    expect(actionBinding).toHaveBeenCalledTimes(2);
+  });
+
+  test("Keeps Windows Backspace separate from Delete shortcuts", () => {
+    CurrentSettings(getDefaultSettings());
+    setPlatform("Win32");
+    const actionBinding = jest.fn();
+
+    SubscribeCommandsToSettingsChanges([MakeRemoveCommand(actionBinding)]);
+    dispatchKeyDown(backspaceKeyCode);
+    expect(actionBinding).not.toHaveBeenCalled();
+
+    dispatchKeyDown(deleteKeyCode);
+    expect(actionBinding).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/Settings/Settings.ts
+++ b/client/Settings/Settings.ts
@@ -8,12 +8,46 @@ import { LegacySynchronousLocalStore } from "../Utility/LegacySynchronousLocalSt
 
 export const CurrentSettings = ko.observable<Settings>();
 
+/**
+ * MacBook keyboards report their Delete key as Backspace, while an external
+ * keyboard can still provide a forward Delete key.
+ */
+export function IsAppleBackspacePlatform(platform: string): boolean {
+  return platform.startsWith("Mac") || platform.startsWith("iPad");
+}
+
+/**
+ * Returns the Backspace equivalent of a Delete-based shortcut.
+ *
+ * @param keyBinding Configured Mousetrap key binding.
+ * @returns Equivalent Backspace binding, or `null` if it has no Delete key.
+ */
+export function GetAppleBackspaceAlias(keyBinding: string): string | null {
+  // Mousetrap sequences (for example, "g i") use spaces between consecutive
+  // key presses; each step can combine keys with "+".
+  const alias = keyBinding
+    .split(" ")
+    .map(keyCombination =>
+      keyCombination
+        .split("+")
+        .map(key => (key === "del" ? "backspace" : key))
+        .join("+")
+    )
+    .join(" ");
+  return alias === keyBinding ? null : alias;
+}
+
 function applyNewCommandSettings(newSettings: Settings, commands: Command[]) {
   Mousetrap.reset();
 
   Mousetrap.bind("backspace", e => {
     e.preventDefault();
   });
+
+  // we need to determine del->backspace alias only for some apple devices
+  const getAppleAlias = IsAppleBackspacePlatform(navigator.platform ?? "") ?
+    GetAppleBackspaceAlias :
+    () => null;
 
   commands.forEach(command => {
     const commandSetting = _.find(
@@ -25,7 +59,13 @@ function applyNewCommandSettings(newSettings: Settings, commands: Command[]) {
       command.ShowOnActionBar(commandSetting.ShowOnActionBar);
       command.ShowInCombatantRow(commandSetting.ShowInCombatantRow);
     }
-    Mousetrap.bind(command.KeyBinding, (e: Event) => {
+
+    const keys = [command.KeyBinding];
+    const appleAlias = getAppleAlias(command.KeyBinding);
+    if (appleAlias) {
+      keys.push(appleAlias);
+    }
+    Mousetrap.bind(keys, (e: Event) => {
       e.preventDefault();
       command.ActionBinding();
     });


### PR DESCRIPTION
Hi, thanks for merging my previous PR! I've got another small QoL improvement suggestion :) 

So, on a MacBook, the default `del` shortcut doesn't work because browsers report that key as Backspace.

This PR preserves existing configured shortcuts while adding a Mac/iPad-only Backspace alias for Delete-based bindings.

For example:

- `del` also works as `backspace`
- `alt+del` also works as `alt+backspace`
- `alt+shift+del` also works as `alt+shift+backspace`

The original forward Delete binding remains active, so external keyboards continue to work normally.

Windows behavior is unchanged: Backspace does not trigger a shortcut configured as `del`.

The alias is applied at binding time only. It does not modify or migrate anyone’s saved shortcut settings.

**Caveat:** I haven't tested it on a Windows machine, but am pretty confident it should not affect anythig.

## Testing

| # | Short name | Description | Unit tested | Manually tested |
| ---: | --- | --- | :---: | :---: |
| 1 | Apple platform detection | Mac platform strings and iPad enable the Backspace alias. | [x] | [ ] |
| 2 | Non-Apple platforms | Windows and iPhone do not enable the alias. | [x] | [ ] |
| 3 | Binding conversion | Plain, modified, and sequence-based `del` bindings convert only standalone Delete keys to Backspace. | [x] | [x] - other shortcuts work |
| 4 | Mac Backspace | A real Mousetrap keydown event for Backspace invokes a command configured as `del`. | [x] | [x] |
| 5 | Mac forward Delete | Forward Delete still invokes that command on Mac. | [x] | [x] |
| 6 | Windows Backspace | Backspace does not invoke a command configured as `del` on Windows. | [x] | [ ] |
| 7 | Windows forward Delete | Forward Delete still invokes the command on Windows. | [x] | [ ] |

Lemme know what you think, would be happy to make any adjustments!

Cheers!