### PR TITLE
Introduce inline rename action for encounters and their folders

### DIFF
--- a/client/Commands/LibrariesCommander.rename.test.ts
+++ b/client/Commands/LibrariesCommander.rename.test.ts
@@ -1,0 +1,246 @@
+import * as ko from "knockout";
+import { SavedEncounter } from "../../common/SavedEncounter";
+import { Listing } from "../Library/Listing";
+import { LibrariesCommander } from "./LibrariesCommander";
+
+function buildListing(id: string, name: string, path: string) {
+  const encounter: SavedEncounter = {
+    ...SavedEncounter.Default(),
+    Id: id,
+    Name: name,
+    Path: path
+  };
+  return new Listing<SavedEncounter>(
+    {
+      Id: id,
+      Name: name,
+      Path: path,
+      Link: "",
+      SearchHint: "",
+      FilterDimensions: {},
+      LastUpdateMs: 0
+    },
+    "localAsync",
+    encounter
+  );
+}
+
+function setup(
+  listings: Listing<SavedEncounter>[],
+  defaults: { Name: string; Path: string } | null = null,
+  updateSucceeded = true
+) {
+  const SaveEncounterDefaults = ko.observable(defaults);
+  const UpdateListings = jest.fn(async updates => {
+    for (const update of updates) {
+      update.listing.SetValue(update.value);
+    }
+    if (!updateSucceeded) {
+      throw new Error("Could not update listings.");
+    }
+  });
+  const library = {
+    GetAllListings: () => listings,
+    UpdateListings
+  };
+  const commander = new LibrariesCommander(
+    { Encounter: { SaveEncounterDefaults } } as any,
+    null as any
+  );
+  commander.SetLibraries({ Encounters: library } as any);
+
+  return { commander, SaveEncounterDefaults, UpdateListings };
+}
+
+describe("LibrariesCommander encounter rename", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("renames an encounter and updates matching save defaults", async () => {
+    const source = buildListing("source-id", "Goblin Ambush", "Chapter 1");
+    const { commander, SaveEncounterDefaults, UpdateListings } = setup(
+      [source],
+      { Name: "Goblin Ambush", Path: "Chapter 1" }
+    );
+
+    const result = await commander.RenameEncounter(source, "Finale");
+
+    expect(result).toEqual({ success: true });
+    expect(UpdateListings).toHaveBeenCalledWith([
+      {
+        listing: source,
+        value: expect.objectContaining({
+          Id: "source-id",
+          Name: "Finale",
+          Path: "Chapter 1"
+        })
+      }
+    ]);
+    expect(SaveEncounterDefaults()).toEqual({
+      Name: "Finale",
+      Path: "Chapter 1"
+    });
+  });
+
+  test("rejects an encounter collision without writes", async () => {
+    const source = buildListing("source-id", "Goblin Ambush", "Chapter 1");
+    const target = buildListing("target-id", "Finale", "Chapter 1");
+    const { commander, SaveEncounterDefaults, UpdateListings } = setup(
+      [source, target],
+      { Name: "Goblin Ambush", Path: "Chapter 1" }
+    );
+
+    const result = await commander.RenameEncounter(source, "Finale");
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.any(String)
+    });
+    expect(UpdateListings).not.toHaveBeenCalled();
+    expect(SaveEncounterDefaults()).toEqual({
+      Name: "Goblin Ambush",
+      Path: "Chapter 1"
+    });
+  });
+
+  test("rejects an empty encounter name without writes", async () => {
+    const source = buildListing("source-id", "Goblin Ambush", "Chapter 1");
+    const { commander, UpdateListings } = setup([source]);
+
+    const result = await commander.RenameEncounter(source, "   ");
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.any(String)
+    });
+    expect(UpdateListings).not.toHaveBeenCalled();
+  });
+
+  test("accepts an unchanged encounter name without writes", async () => {
+    const source = buildListing("source-id", "Goblin Ambush", "Chapter 1");
+    const { commander, UpdateListings } = setup([source]);
+
+    const result = await commander.RenameEncounter(source, "  Goblin Ambush  ");
+
+    expect(result).toEqual({ success: true });
+    expect(UpdateListings).not.toHaveBeenCalled();
+  });
+
+  test("reports a failed encounter update and leaves defaults unchanged", async () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const source = buildListing("source-id", "Goblin Ambush", "Chapter 1");
+    const { commander, SaveEncounterDefaults } = setup(
+      [source],
+      { Name: "Goblin Ambush", Path: "Chapter 1" },
+      false
+    );
+
+    const result = await commander.RenameEncounter(source, "Finale");
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.any(String)
+    });
+    expect(SaveEncounterDefaults()).toEqual({
+      Name: "Goblin Ambush",
+      Path: "Chapter 1"
+    });
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  });
+
+  test("renames a complete folder subtree and updates save defaults", async () => {
+    const first = buildListing("first", "Ambush", "Campaign/Act One");
+    const second = buildListing("second", "Finale", "Campaign/Act One/Deep");
+    const unrelated = buildListing("other", "Tavern", "Campaign/Side Quest");
+    const { commander, SaveEncounterDefaults, UpdateListings } = setup(
+      [first, second, unrelated],
+      { Name: "Finale", Path: "Campaign/Act One/Deep" }
+    );
+
+    const result = await commander.RenameEncounterFolder(
+      "Campaign/Act One",
+      "Act 1"
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(UpdateListings).toHaveBeenCalledWith([
+      {
+        listing: first,
+        value: expect.objectContaining({ Path: "Campaign/Act 1" })
+      },
+      {
+        listing: second,
+        value: expect.objectContaining({ Path: "Campaign/Act 1/Deep" })
+      }
+    ]);
+    expect(SaveEncounterDefaults()).toEqual({
+      Name: "Finale",
+      Path: "Campaign/Act 1/Deep"
+    });
+  });
+
+  test("rejects a folder collision without writes", async () => {
+    const source = buildListing("source", "Ambush", "Campaign/Act One");
+    const target = buildListing("target", "Finale", "Campaign/Act Two/Deep");
+    const { commander, UpdateListings } = setup([source, target]);
+
+    const result = await commander.RenameEncounterFolder(
+      "Campaign/Act One",
+      "Act Two"
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.any(String)
+    });
+    expect(UpdateListings).not.toHaveBeenCalled();
+  });
+
+  test("rejects a slash in a folder name without writes", async () => {
+    const source = buildListing("source", "Ambush", "Campaign/Act One");
+    const { commander, UpdateListings } = setup([source]);
+
+    const result = await commander.RenameEncounterFolder(
+      "Campaign/Act One",
+      "Act/One"
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.any(String)
+    });
+    expect(UpdateListings).not.toHaveBeenCalled();
+  });
+
+  test("rejects an empty folder name without writes", async () => {
+    const source = buildListing("source", "Ambush", "Campaign/Act One");
+    const { commander, UpdateListings } = setup([source]);
+
+    const result = await commander.RenameEncounterFolder(
+      "Campaign/Act One",
+      "   "
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: expect.any(String)
+    });
+    expect(UpdateListings).not.toHaveBeenCalled();
+  });
+
+  test("accepts an unchanged folder name without writes", async () => {
+    const source = buildListing("source", "Ambush", "Campaign/Act One");
+    const { commander, UpdateListings } = setup([source]);
+
+    const result = await commander.RenameEncounterFolder(
+      "Campaign/Act One",
+      "  Act One  "
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(UpdateListings).not.toHaveBeenCalled();
+  });
+});

--- a/client/Commands/LibrariesCommander.ts
+++ b/client/Commands/LibrariesCommander.ts
@@ -24,6 +24,19 @@ import { SavedEncounter } from "../../common/SavedEncounter";
 import { now } from "moment";
 import { Library } from "../Library/useLibrary";
 import { CurrentSettings } from "../Settings/Settings";
+import { RenameResult } from "../Library/RenameResult";
+
+const makeRenameCollisionError = (name: string, path: string, type: string) => {
+  return `The ${type} named "${name}" already exists${
+    path ? ` in "${path}"` : ""
+  }. Rename that ${type} first, then try again.`;
+};
+
+const isPathUnderFolder = (path: string, target: string) =>
+  path === target || path.startsWith(`${target}/`);
+
+const isListingUnderFolder = (listing: Listing<any>, target: string) =>
+   isPathUnderFolder(listing.Meta().Path, target);
 
 export class LibrariesCommander {
   private libraries: Libraries;
@@ -266,6 +279,9 @@ export class LibrariesCommander {
     this.encounterCommander.LoadSavedEncounter(savedEncounter);
   };
 
+  // TODO(encounter-library-collisions): Maybe reuse the rename collision checks and
+  // add explicit handling before legacy save, move, or Library Manager
+  // overwrite. Make sure to allow saves of the same-ID encounters.
   public SaveEncounter = (): void => {
     const saveEncounterDefaults = this.tracker.Encounter.SaveEncounterDefaults();
     const saveEncounterToLibrary = (newEncounter: SavedEncounter) => {
@@ -306,6 +322,151 @@ export class LibrariesCommander {
       folderNames
     );
     this.tracker.PromptQueue.Add(prompt);
+  };
+
+  /**
+   * Renames one saved encounter in place.
+   * Could later be reused for inline renaming of other listings.
+   * Rejects a name/path collision before performing any write.
+   */
+  public RenameEncounter = async (
+    encounterListing: Listing<SavedEncounter>,
+    newName: string
+  ): Promise<RenameResult> => {
+    newName = newName.trim();
+    if (!newName) {
+      return { success: false, error: "Name cannot be empty." };
+    }
+
+    const source = encounterListing.Meta();
+    if (newName === source.Name) {
+      return { success: true };
+    }
+    const collision = this.libraries.Encounters.GetAllListings().some(target =>
+        target.Meta().Id !== source.Id &&
+        target.Meta().Path === source.Path &&
+        target.Meta().Name === newName
+    );
+    if (collision) {
+      return {
+        success: false,
+        error: makeRenameCollisionError(newName, source.Path, "encounter")
+      };
+    }
+
+    try {
+      const encounter = await encounterListing.GetWithTemplate(SavedEncounter.Default());
+      await this.libraries.Encounters.UpdateListings([
+        {
+          listing: encounterListing,
+          value: { ...encounter, Id: source.Id, Name: newName }
+        }
+      ]);
+      const defaults = this.tracker.Encounter.SaveEncounterDefaults();
+      // Defaults have no stable ID, so the complete old tuple is the safest
+      // available way to determine whether they refer to this encounter.
+      // TODO: add stable ID to the defaults and use that
+      if (defaults?.Name === source.Name && defaults.Path === source.Path) {
+        this.tracker.Encounter.SaveEncounterDefaults({
+          Name: newName,
+          Path: source.Path
+        });
+      }
+      return { success: true };
+    } catch (e) {
+      console.error("Encounter renaming error", e);
+      return {
+        success: false,
+        error:
+          "Unexpected error during renaming an encounter. Please try again."
+      };
+    }
+  };
+
+  /**
+   * Renames one virtual encounter folder and rewrites every descendant path.
+   * Could later be reused for inline renaming folders of other listings.
+   * Rejects an existing destination subtree before performing any write.
+   *
+   */
+  public RenameEncounterFolder = async (
+    sourcePath: string,
+    newName: string
+  ): Promise<RenameResult> => {
+    newName = newName.trim();
+    if (!newName) {
+      return { success: false, error: "Name cannot be empty." };
+    }
+    if (newName.includes("/")) {
+      return { success: false, error: "Folder names cannot contain a slash." };
+    }
+
+    const parentPath = sourcePath.split("/").slice(0, -1).join("/");
+    const targetPath = parentPath ? `${parentPath}/${newName}` : newName;
+    if (targetPath === sourcePath) {
+      return { success: true };
+    }
+
+    const listings = this.libraries.Encounters.GetAllListings();
+
+    // if any listings exist in the traget path - abort
+    const collision = listings.some(listing => isListingUnderFolder(listing, targetPath));
+    if (collision) {
+      return {
+        success: false,
+        error: makeRenameCollisionError(newName, parentPath, "folder")
+      };
+    }
+
+    const affectedListingsById = new Map<string, Listing<SavedEncounter>>();
+    // Account and local rows can share an ID. Prefer a local row when present
+    // and produce one update for each logical encounter.
+    for (const listing of listings) {
+      if (!isListingUnderFolder(listing, sourcePath)) {
+        continue;
+      }
+      const id = listing.Meta().Id;
+      const current = affectedListingsById.get(id);
+      if (!current || current.Origin === "account") {
+        affectedListingsById.set(id, listing);
+      }
+    }
+
+    try {
+      // Preserve the descendant path; only the selected folder
+      // segment and its parent prefix are replaced.
+      const getNewPath = (oldPath: string) =>
+        targetPath + oldPath.slice(sourcePath.length)
+
+      const updates = await Promise.all(
+        Array.from(affectedListingsById.values()).map(async listing => {
+          const encounter = await listing.GetWithTemplate(SavedEncounter.Default());
+          const {Id, Path} = listing.Meta();
+          return {
+            listing,
+            value: {...encounter, Id, Path: getNewPath(Path)
+            }
+          };
+        })
+      );
+      await this.libraries.Encounters.UpdateListings(updates);
+
+      const defaults = this.tracker.Encounter.SaveEncounterDefaults();
+      if (defaults && isPathUnderFolder(defaults.Path, sourcePath)) {
+        this.tracker.Encounter.SaveEncounterDefaults({
+          Name: defaults.Name,
+          Path: getNewPath(defaults.Path)
+        });
+      }
+      return { success: true };
+    } catch (e) {
+      console.error("Folder renaming error", e);
+      return {
+        success: false,
+        error:
+          "Unexpected error during renaming a folder. Please try again."
+      };
+    }
   };
 
   public ReferenceCondition = (conditionName: string): void => {

--- a/client/Library/Components/BuildListingTree.test.tsx
+++ b/client/Library/Components/BuildListingTree.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { render } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { Listing } from "../Listing";
 import { BuildListingTree } from "./BuildListingTree";
 import { act } from "react-dom/test-utils";
@@ -44,6 +44,7 @@ describe("BuildListingTree", () => {
     const rendered = render(<div>{listingTree}</div>);
     const outerFolder = rendered.getByText("Outer");
     expect(outerFolder).toBeTruthy();
+    expect(rendered.container.querySelector(".c-listing-edit")).toBeNull();
     act(() => {
       rendered.getByText("Outer").click();
     });
@@ -63,5 +64,47 @@ describe("BuildListingTree", () => {
 
     const innerListing2 = rendered.queryByText("Listing 2");
     expect(innerListing2).toBeFalsy();
+  });
+
+  it("Propagates optional rename behavior with the complete folder path", async () => {
+    const onRenameFolder = jest.fn().mockResolvedValue({ success: true });
+    const listingTree = BuildListingTree(
+      listing => <div key={listing.Meta().Id}>{listing.Meta().Name}</div>,
+      {
+        groupFn: listing => ({ key: listing.Meta().Path })
+      },
+      [
+        new Listing(
+          {
+            Name: "Listing 1",
+            Id: "1",
+            Path: "Outer/Inner",
+            LastUpdateMs: 0,
+            FilterDimensions: {},
+            Link: "",
+            SearchHint: ""
+          },
+          "localAsync"
+        )
+      ],
+      onRenameFolder
+    );
+    const rendered = render(<div>{listingTree}</div>);
+
+    fireEvent.click(rendered.getByText("Outer"));
+    fireEvent.click(rendered.getByText("Inner"));
+    const innerFolderRow = rendered
+      .getByText("Inner")
+      .closest("li") as HTMLElement;
+    fireEvent.click(
+      innerFolderRow.querySelector(".c-listing-edit") as HTMLElement
+    );
+    const input = innerFolderRow.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Renamed" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() =>
+      expect(onRenameFolder).toHaveBeenCalledWith("Outer/Inner", "Renamed")
+    );
   });
 });

--- a/client/Library/Components/BuildListingTree.tsx
+++ b/client/Library/Components/BuildListingTree.tsx
@@ -2,6 +2,7 @@ import * as _ from "lodash";
 import * as React from "react";
 import { Listable } from "../../../common/Listable";
 import { Listing } from "../Listing";
+import { RenameResult } from "../RenameResult";
 import { Folder } from "./Folder";
 
 export type ListingGroup = {
@@ -19,6 +20,12 @@ type FolderModel = {
   subFoldersByKey: Record<string, FolderModel>;
 };
 
+/** Renames the folder identified by its complete slash-delimited path. */
+export type RenameFolder = (
+  path: string,
+  newName: string
+) => Promise<RenameResult>;
+
 export function BuildListingTree<T extends Listable>(
   buildListingComponent: (
     listing: Listing<T>,
@@ -26,7 +33,8 @@ export function BuildListingTree<T extends Listable>(
     array: Listing<T>[]
   ) => JSX.Element,
   listingGroup: ListingGroup,
-  listings: Listing<T>[]
+  listings: Listing<T>[],
+  onRenameFolder?: RenameFolder
 ): JSX.Element[] {
   const rootListingComponents: JSX.Element[] = [];
 
@@ -51,7 +59,9 @@ export function BuildListingTree<T extends Listable>(
 
   const folderComponents = buildFolderComponents<T>(
     foldersByKey,
-    buildListingComponent
+    buildListingComponent,
+    onRenameFolder,
+    ""
   );
 
   return folderComponents.concat(rootListingComponents);
@@ -63,16 +73,31 @@ function buildFolderComponents<T extends Listable>(
     listing: Listing<T>,
     index: number,
     array: Listing<T>[]
-  ) => JSX.Element
+  ) => JSX.Element,
+  onRenameFolder: RenameFolder | undefined,
+  parentPath: string
 ) {
   return Object.keys(foldersByKey)
     .sort()
     .map(key => {
       const folder = foldersByKey[key];
+      // Folder labels contain only one segment, while rename commands need the
+      // complete path so the correct nested subtree can be updated.
+      const path = parentPath ? `${parentPath}/${key}` : key;
       const listingComponents = folder.listings.map(buildListingComponent);
       return (
-        <Folder key={key} name={folder.label}>
-          {buildFolderComponents(folder.subFoldersByKey, buildListingComponent)}
+        <Folder
+          key={key}
+          name={folder.label}
+          path={path}
+          onRename={onRenameFolder}
+        >
+          {buildFolderComponents(
+            folder.subFoldersByKey,
+            buildListingComponent,
+            onRenameFolder,
+            path
+          )}
           {listingComponents}
         </Folder>
       );

--- a/client/Library/Components/Folder.tsx
+++ b/client/Library/Components/Folder.tsx
@@ -1,8 +1,20 @@
 import * as React from "react";
+import { RenameResult } from "../RenameResult";
+import { InlineNameEditor } from "./InlineNameEditor";
 import { ListingButton } from "./ListingButton";
 
-export function Folder(props: { name: string; children: React.ReactNode }) {
+interface FolderProps {
+  name: string;
+  /** Complete logical path; `name` contains only the displayed segment. */
+  path: string;
+  children: React.ReactNode;
+  onRename?: (path: string, newName: string) => Promise<RenameResult>;
+}
+
+/** Renders one expandable library folder with an optional inline rename. */
+export function Folder(props: FolderProps) {
   const [isOpen, setOpen] = React.useState(false);
+  const [isRenaming, setRenaming] = React.useState(false);
   const toggleOpen = () => setOpen(!isOpen);
   return (
     <div
@@ -12,14 +24,30 @@ export function Folder(props: { name: string; children: React.ReactNode }) {
       }
     >
       <li className="c-listing">
-        <ListingButton
-          text={props.name}
-          buttonClass="toggle"
-          faClass={
-            (isOpen ? "folder-open" : "folder") + " c-listing-button--wide"
-          }
-          onClick={toggleOpen}
-        />
+        {isRenaming ? (
+          <InlineNameEditor
+            name={props.name}
+            onCancel={() => setRenaming(false)}
+            onCommit={newName => props.onRename(props.path, newName)}
+          />
+        ) : (
+          <ListingButton
+            text={props.name}
+            buttonClass="toggle"
+            faClass={
+              (isOpen ? "folder-open" : "folder") + " c-listing-button--wide"
+            }
+            onClick={toggleOpen}
+          />
+        )}
+        {props.onRename && (
+          <ListingButton
+            title="Rename"
+            buttonClass="edit"
+            faClass="i-cursor"
+            onClick={() => setRenaming(true)}
+          />
+        )}
       </li>
       {isOpen && props.children}
     </div>

--- a/client/Library/Components/InlineNameEditor.test.tsx
+++ b/client/Library/Components/InlineNameEditor.test.tsx
@@ -1,0 +1,140 @@
+import * as React from "react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
+import { RenameResult } from "../RenameResult";
+import { InlineNameEditor } from "./InlineNameEditor";
+
+function getInput(container: HTMLElement) {
+  return container.querySelector("input") as HTMLInputElement;
+}
+
+describe("InlineNameEditor", () => {
+  test("focuses the input and commits the edited name with Enter", async () => {
+    const onCommit = jest.fn().mockResolvedValue({ success: true });
+    const rendered = render(
+      <InlineNameEditor
+        name="Goblin Ambush"
+        onCancel={jest.fn()}
+        onCommit={onCommit}
+      />
+    );
+
+    const input = getInput(rendered.container);
+    expect(document.activeElement).toBe(input);
+
+    fireEvent.change(input, { target: { value: "Finale" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => expect(onCommit).toHaveBeenCalledWith("Finale"));
+  });
+
+  test("discards with Escape or blur", () => {
+    const onCancel = jest.fn();
+    const rendered = render(
+      <InlineNameEditor
+        name="Goblin Ambush"
+        onCancel={onCancel}
+        onCommit={jest.fn()}
+      />
+    );
+
+    const input = getInput(rendered.container);
+    fireEvent.keyDown(input, {
+      key: "Escape"
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    rendered.rerender(
+      <InlineNameEditor
+        name="Goblin Ambush"
+        onCancel={onCancel}
+        onCommit={jest.fn()}
+      />
+    );
+    fireEvent.blur(getInput(rendered.container));
+    expect(onCancel).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not duplicate or discard a commit while saving", () => {
+    const onCancel = jest.fn();
+    const onCommit = jest
+      .fn()
+      .mockImplementation(() => new Promise<RenameResult>(() => {}));
+    const rendered = render(
+      <InlineNameEditor
+        name="Goblin Ambush"
+        onCancel={onCancel}
+        onCommit={onCommit}
+      />
+    );
+
+    const input = getInput(rendered.container);
+    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.blur(input);
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  test("ignores a failed commit after the editor unmounts", async () => {
+    const resolveCommit: {
+      current?: (result: RenameResult) => void;
+    } = {};
+    const onCommit = jest.fn().mockImplementation(
+      () =>
+        new Promise<RenameResult>(resolve => {
+          resolveCommit.current = resolve;
+        })
+    );
+    const rendered = render(
+      <InlineNameEditor
+        name="Goblin Ambush"
+        onCancel={jest.fn()}
+        onCommit={onCommit}
+      />
+    );
+
+    fireEvent.keyDown(getInput(rendered.container), {
+      key: "Enter"
+    });
+    rendered.unmount();
+    await act(async () => {
+      resolveCommit.current!({ success: false, error: "Rename error" });
+    });
+
+    expect(document.body.textContent).not.toContain("Rename error");
+  });
+
+  test("keeps editing and displays rename feedback in a popup", async () => {
+    const renameError = "Rename error";
+    const onCommit = jest.fn().mockResolvedValue({
+      success: false,
+      error: renameError
+    });
+    const rendered = render(
+      <InlineNameEditor
+        name="Goblin Ambush"
+        onCancel={jest.fn()}
+        onCommit={onCommit}
+      />
+    );
+
+    const input = getInput(rendered.container);
+    fireEvent.change(input, { target: { value: "Finale" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() =>
+      expect(document.body.textContent).toContain(renameError)
+    );
+    expect(
+      document.querySelector('.tippy-box[data-theme~="error-message"]')
+    ).not.toBeNull();
+    expect(document.activeElement).toBe(input);
+    expect(input.value).toBe("Finale");
+
+    fireEvent.change(input, { target: { value: "Finale revised" } });
+    await waitFor(() =>
+      expect(document.body.textContent).not.toContain(renameError)
+    );
+  });
+});

--- a/client/Library/Components/InlineNameEditor.tsx
+++ b/client/Library/Components/InlineNameEditor.tsx
@@ -1,0 +1,78 @@
+import Tippy from "@tippyjs/react";
+import * as React from "react";
+import { RenameResult } from "../RenameResult";
+
+interface InlineNameEditorProps {
+  name: string;
+  onCancel: () => void;
+  onCommit: (name: string) => Promise<RenameResult>;
+}
+
+/**
+ * Edits one display name in place and delegates persistence to an async
+ * command. Enter commits; Escape and blur discard the draft.
+ */
+export function InlineNameEditor(props: InlineNameEditorProps): JSX.Element {
+  const [name, setName] = React.useState(props.name);
+  const [isSaving, setSaving] = React.useState(false);
+  const [error, setError] = React.useState<string>();
+  const input = React.useRef<HTMLInputElement>();
+
+  React.useEffect(() => {
+    input.current?.focus();
+  }, []);
+
+  const commit = async () => {
+    if (isSaving) {
+      return;
+    }
+
+    setError(undefined);
+    setSaving(true);
+    const result = await props.onCommit(name);
+
+    // Folder updates can rebuild the path-keyed tree before persistence reports
+    // its final result. Do not update an editor that was removed by that rebuild.
+    if (!input.current) {
+      return;
+    }
+
+    if (result.success === true) {
+      // Close the editor when a no-op rename leaves the existing row mounted.
+      return props.onCancel();
+    }
+
+    setError(result.error || "Unexpected error");
+    setSaving(false);
+    input.current.focus();
+  };
+
+  return (
+    <Tippy content={error} visible={Boolean(error)} theme="error-message">
+      <input
+        ref={input}
+        className="c-listing-button--wide"
+        value={name}
+        readOnly={isSaving}
+        onChange={event => {
+          setName(event.target.value);
+          setError(undefined);
+        }}
+        onBlur={() => {
+          if (!isSaving) {
+            props.onCancel();
+          }
+        }}
+        onKeyDown={event => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            commit();
+          } else if (event.key === "Escape") {
+            event.preventDefault();
+            props.onCancel();
+          }
+        }}
+      />
+    </Tippy>
+  );
+}

--- a/client/Library/Components/ListingButton.tsx
+++ b/client/Library/Components/ListingButton.tsx
@@ -1,3 +1,4 @@
+import Tippy from "@tippyjs/react";
 import * as React from "react";
 
 interface Props {
@@ -11,6 +12,7 @@ interface Props {
   children?: React.ReactNode;
 }
 
+/** Renders a library-row action using the existing icon and tooltip styles. */
 export function ListingButton(props: Props) {
   const text = props.text || "";
 
@@ -19,15 +21,16 @@ export function ListingButton(props: Props) {
     cssClasses.push("fas", `fa-${props.faClass}`);
   }
 
-  return (
+  const button = (
     <span
       className={cssClasses.join(" ")}
       onClick={props.onClick}
       onMouseEnter={props.onMouseEnter}
       onMouseLeave={props.onMouseLeave}
-      title={props.title}
     >
       {text} {props.children}
     </span>
   );
+
+  return props.title ? <Tippy content={props.title}>{button}</Tippy> : button;
 }

--- a/client/Library/Components/ListingRow.test.tsx
+++ b/client/Library/Components/ListingRow.test.tsx
@@ -1,0 +1,97 @@
+import * as React from "react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { SavedEncounter } from "../../../common/SavedEncounter";
+import { Listing } from "../Listing";
+import { ListingRow } from "./ListingRow";
+
+function getElement(container: HTMLElement, selector: string) {
+  return container.querySelector(selector) as HTMLElement;
+}
+
+describe("ListingRow rename", () => {
+  test("supports optional inline rename and titles row actions", async () => {
+    const encounter = {
+      ...SavedEncounter.Default(),
+      Id: "encounter-1",
+      Name: "Goblin Ambush",
+      Path: "Chapter 1"
+    };
+    const listing = new Listing<SavedEncounter>(
+      {
+        Id: encounter.Id,
+        Name: encounter.Name,
+        Path: encounter.Path,
+        Link: "",
+        SearchHint: "",
+        FilterDimensions: {},
+        LastUpdateMs: 0
+      },
+      "localAsync",
+      encounter
+    );
+    const onRename = jest.fn().mockResolvedValue({ success: true });
+    const rendered = render(
+      <ListingRow
+        name={encounter.Name}
+        listing={listing}
+        onAdd={() => true}
+        onDelete={jest.fn()}
+        onMove={jest.fn()}
+        onPreview={jest.fn()}
+        onRename={onRename}
+      />
+    );
+
+    const deleteButton = getElement(rendered.container, ".c-listing-delete");
+    const moveButton = getElement(rendered.container, ".c-listing-move");
+    fireEvent.mouseEnter(deleteButton);
+    expect(await rendered.findByText("Delete")).toBeTruthy();
+    fireEvent.mouseLeave(deleteButton);
+    fireEvent.mouseEnter(moveButton);
+    expect(await rendered.findByText("Move")).toBeTruthy();
+    fireEvent.mouseLeave(moveButton);
+    expect(rendered.container.querySelector(".c-listing-preview")).toBeTruthy();
+
+    const rename = getElement(rendered.container, ".c-listing-edit");
+    fireEvent.mouseEnter(rename);
+    expect(await rendered.findByText("Rename")).toBeTruthy();
+    fireEvent.click(rename);
+    const input = getElement(rendered.container, "input");
+    fireEvent.change(input, { target: { value: "Finale" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() =>
+      expect(onRename).toHaveBeenCalledWith(listing, "Finale")
+    );
+  });
+
+  test("omits rename when its callback is absent", async () => {
+    const listing = new Listing<SavedEncounter>(
+      {
+        Id: "encounter-1",
+        Name: "Goblin Ambush",
+        Path: "",
+        Link: "",
+        SearchHint: "",
+        FilterDimensions: {},
+        LastUpdateMs: 0
+      },
+      "localAsync"
+    );
+    const rendered = render(
+      <ListingRow
+        name={listing.Meta().Name}
+        listing={listing}
+        onAdd={() => true}
+        onEdit={jest.fn()}
+      />
+    );
+
+    expect(rendered.container.querySelectorAll(".c-listing-edit")).toHaveLength(
+      1
+    );
+    const edit = getElement(rendered.container, ".c-listing-edit");
+    fireEvent.mouseEnter(edit);
+    expect(await rendered.findByText("Edit")).toBeTruthy();
+  });
+});

--- a/client/Library/Components/ListingRow.tsx
+++ b/client/Library/Components/ListingRow.tsx
@@ -4,6 +4,8 @@ import * as React from "react";
 import { Listable } from "../../../common/Listable";
 import { linkComponentToObservables } from "../../Combatant/linkComponentToObservables";
 import { Listing } from "../Listing";
+import { RenameResult } from "../RenameResult";
+import { InlineNameEditor } from "./InlineNameEditor";
 import { ListingButton } from "./ListingButton";
 
 export interface ExtraButton<T extends Listable> {
@@ -28,10 +30,13 @@ export interface ListingProps<T extends Listable> {
   extraButtons?: ExtraButton<T>[];
   showCount?: boolean;
   showSource?: boolean;
+  /** Persists a rename and reports a recoverable result to the editor. */
+  onRename?: (listing: Listing<T>, newName: string) => Promise<RenameResult>;
 }
 
 interface ListingState {
   count: number;
+  isRenaming?: boolean;
 }
 
 export class ListingRow<T extends Listable> extends React.Component<
@@ -77,24 +82,33 @@ export class ListingRow<T extends Listable> extends React.Component<
         ))
       : "";
 
-    let name = this.props.name;
+    const listingName = this.props.listing.Meta().Name;
+    let displayName = listingName;
     if (this.props.showSource) {
       const source = this.props.listing.Meta().FilterDimensions.Source;
       if (source?.length) {
-        name += ` (${source})`;
+        displayName += ` (${source})`;
       }
     }
 
     const extraButtons = this.props.extraButtons || [];
     return (
       <li className="c-listing">
-        <ListingButton
-          buttonClass="add c-listing-button--wide"
-          text={name}
-          onClick={this.addFn}
-        >
-          {countElements}
-        </ListingButton>
+        {this.state?.isRenaming ? (
+          <InlineNameEditor
+            name={listingName}
+            onCancel={() => this.setState({ isRenaming: false })}
+            onCommit={(newName) => this.props.onRename(this.props.listing, newName)}
+          />
+        ) : (
+          <ListingButton
+            buttonClass="add c-listing-button--wide"
+            text={displayName}
+            onClick={this.addFn}
+          >
+            {countElements}
+          </ListingButton>
+        )}
         {extraButtons.map((button, index) => (
           <ListingButton
             key={index}
@@ -104,8 +118,17 @@ export class ListingRow<T extends Listable> extends React.Component<
             onClick={this.makeExtraButtonFn(button)}
           />
         ))}
+        {this.props.onRename && (
+          <ListingButton
+            title="Rename"
+            buttonClass="edit"
+            faClass="i-cursor"
+            onClick={() => this.setState({ isRenaming: true })}
+          />
+        )}
         {this.props.onDelete && (
           <ListingButton
+            title="Delete"
             buttonClass="delete"
             faClass="trash"
             onClick={this.deleteFn}
@@ -113,6 +136,7 @@ export class ListingRow<T extends Listable> extends React.Component<
         )}
         {this.props.onEdit && (
           <ListingButton
+            title="Edit"
             buttonClass="edit"
             faClass="edit"
             onClick={this.editFn}
@@ -120,6 +144,7 @@ export class ListingRow<T extends Listable> extends React.Component<
         )}
         {this.props.onMove && (
           <ListingButton
+            title="Move"
             buttonClass="move"
             faClass="folder"
             onClick={this.moveFn}

--- a/client/Library/Libraries.ts
+++ b/client/Library/Libraries.ts
@@ -70,7 +70,8 @@ function dummyLibrary<T extends Listable>(): Library<T> {
     GetAllListings: () => [],
     GetOrCreateListingById: () => Promise.resolve(null),
     SaveEditedListing: () => Promise.resolve(null),
-    SaveNewListing: () => Promise.resolve(null)
+    SaveNewListing: () => Promise.resolve(null),
+    UpdateListings: () => Promise.resolve()
   };
 }
 

--- a/client/Library/ReferencePane/EncounterLibraryReferencePane.tsx
+++ b/client/Library/ReferencePane/EncounterLibraryReferencePane.tsx
@@ -29,6 +29,7 @@ export class EncounterLibraryReferencePane extends React.Component<EncounterLibr
         defaultItem={SavedEncounter.Default()}
         renderListingRow={this.renderListingRow}
         listingGroups={this.listingGroups}
+        onRenameFolder={this.renameFolder}
         addNewItem={this.props.librariesCommander.SaveEncounter}
         addNewText="Save Current Encounter"
         renderPreview={this.renderPreview}
@@ -51,6 +52,7 @@ export class EncounterLibraryReferencePane extends React.Component<EncounterLibr
         onMove={this.moveListing}
         onPreview={onPreview}
         onPreviewOut={onPreviewOut}
+        onRename={this.renameListing}
         listing={l}
         showCount
       />
@@ -79,4 +81,10 @@ export class EncounterLibraryReferencePane extends React.Component<EncounterLibr
   private moveListing = (listing: EncounterListing) => {
     this.props.librariesCommander.MoveEncounter(listing);
   };
+
+  private renameListing = (listing: EncounterListing, newName: string) =>
+    this.props.librariesCommander.RenameEncounter(listing, newName);
+
+  private renameFolder = (path: string, newName: string) =>
+    this.props.librariesCommander.RenameEncounterFolder(path, newName);
 }

--- a/client/Library/ReferencePane/LibraryReferencePane.tsx
+++ b/client/Library/ReferencePane/LibraryReferencePane.tsx
@@ -4,7 +4,11 @@ import { Button } from "../../Components/Button";
 import { Overlay } from "../../Components/Overlay";
 import { FilterCache } from "../FilterCache";
 import { Listing } from "../Listing";
-import { BuildListingTree, ListingGroup } from "../Components/BuildListingTree";
+import {
+  BuildListingTree,
+  ListingGroup,
+  RenameFolder
+} from "../Components/BuildListingTree";
 import { LibraryFilter } from "../Components/LibraryFilter";
 import { ListingButton } from "../Components/ListingButton";
 import { CurrentSettings } from "../../Settings/Settings";
@@ -28,6 +32,7 @@ interface LibraryReferencePaneProps<T extends Listable> {
   showPreloadInfo?: boolean;
   showSortControl?: boolean;
   launchQuickAddPrompt?: () => void;
+  onRenameFolder?: RenameFolder;
 }
 
 interface State<T extends Listable> {
@@ -97,7 +102,8 @@ export class LibraryReferencePane<T extends Listable> extends React.Component<
         );
       },
       grouping,
-      filteredListings
+      filteredListings,
+      this.props.onRenameFolder
     );
 
     const previewVisible =

--- a/client/Library/RenameResult.ts
+++ b/client/Library/RenameResult.ts
@@ -1,0 +1,9 @@
+/**
+ * Result returned by an inline rename command.
+ *
+ * Failures are recoverable: the editor keeps the draft active and presents
+ * the supplied message without applying the requested rename.
+ */
+export type RenameResult =
+  | { success: true }
+  | { success: false; error: string };

--- a/client/Library/SavedEncounterLibrary.test.tsx
+++ b/client/Library/SavedEncounterLibrary.test.tsx
@@ -1,7 +1,9 @@
 import { act, renderHook } from "@testing-library/react-hooks";
 import { SavedEncounter } from "../../common/SavedEncounter";
 import { Store } from "../Utility/Store";
+import { FilterCache } from "./FilterCache";
 import { useLibrary } from "./useLibrary";
+import { Listing } from "./Listing";
 
 function buildSavedEncounter(
   Id: string,
@@ -27,11 +29,13 @@ describe("Saved Encounter Library", () => {
     jest.restoreAllMocks();
   });
 
-  function renderSavedEncounterLibrary() {
+  function renderSavedEncounterLibrary(
+    accountSave: (encounter: SavedEncounter) => any = () => undefined
+  ) {
     return renderHook(() =>
       useLibrary(Store.SavedEncounters, "encounters", {
         createEmptyListing: SavedEncounter.Default,
-        accountSave: () => undefined,
+        accountSave,
         accountDelete: () => undefined,
         getSearchHint: SavedEncounter.GetSearchHint,
         getFilterDimensions: () => ({})
@@ -87,5 +91,100 @@ describe("Saved Encounter Library", () => {
       "Chapter 1",
       "Chapter 2"
     ]);
+  });
+
+  // TODO(encounter-rename-persistence): Restore the one-row expectation when
+  // UpdateListings stops delegating to the append-based legacy save method.
+  test("the filter hides the duplicate row appended by legacy UpdateListings", async () => {
+    const accountSave = jest.fn();
+    const { result } = renderSavedEncounterLibrary(accountSave);
+    const original = buildSavedEncounter(
+      "encounter-id",
+      "Goblin Ambush",
+      "Chapter 1"
+    );
+
+    await act(async () => {
+      await result.current.SaveNewListing(original);
+    });
+    const listing = result.current.GetAllListings()[0];
+
+    await act(async () => {
+      await result.current.UpdateListings([
+        {
+          listing,
+          value: { ...original, Name: "Finale" }
+        }
+      ]);
+    });
+
+    expect(result.current.GetAllListings()).toHaveLength(2);
+    for (const updatedListing of result.current.GetAllListings()) {
+      expect(updatedListing.Meta()).toMatchObject({
+        Id: "encounter-id",
+        Name: "Finale",
+        Path: "Chapter 1"
+      });
+    }
+    // FilterCache's invariant value type is irrelevant here; this test only
+    // exercises its metadata-based duplicate filtering.
+    const visibleListings = new FilterCache<Listing<any>>(
+      result.current.GetAllListings()
+    ).GetFilteredEntries("");
+    expect(visibleListings).toHaveLength(1);
+    expect(Store.Save).toHaveBeenLastCalledWith(
+      Store.SavedEncounters,
+      "encounter-id",
+      expect.objectContaining({
+        Id: "encounter-id",
+        Name: "Finale"
+      })
+    );
+    expect(accountSave).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        Id: "encounter-id",
+        Name: "Finale"
+      })
+    );
+  });
+
+  test("attempts every update and reports rejected edits", async () => {
+    const accountSave = jest.fn();
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { result } = renderSavedEncounterLibrary(accountSave);
+    const first = buildSavedEncounter("first", "First", "Chapter 1");
+    const second = buildSavedEncounter("second", "Second", "Chapter 1");
+
+    await act(async () => {
+      await result.current.SaveNewListing(first);
+      await result.current.SaveNewListing(second);
+    });
+    const [firstListing, secondListing] = result.current.GetAllListings();
+    accountSave.mockReset();
+    accountSave
+      .mockRejectedValueOnce(new Error("account unavailable"))
+      .mockResolvedValueOnce(undefined);
+
+    await act(async () => {
+      await expect(
+        result.current.UpdateListings([
+          {
+            listing: firstListing,
+            value: { ...first, Name: "First renamed" }
+          },
+          {
+            listing: secondListing,
+            value: { ...second, Name: "Second renamed" }
+          }
+        ])
+      ).rejects.toEqual(expect.any(Error));
+    });
+
+    expect(accountSave).toHaveBeenCalledTimes(2);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError.mock.calls[0][1]).toEqual(expect.any(Error));
+    consoleError.mockRestore();
   });
 });

--- a/client/Library/useLibrary.ts
+++ b/client/Library/useLibrary.ts
@@ -7,6 +7,12 @@ import { probablyUniqueString } from "../../common/Toolbox";
 import { Store } from "../Utility/Store";
 import { Listing, ListingOrigin } from "./Listing";
 
+/** A requested update for one logical library listing. */
+export interface ListingUpdate<T extends Listable> {
+  listing: Listing<T>;
+  value: T;
+}
+
 export interface Library<T extends Listable> {
   AddListings: (
     newListingMetas: ListingMeta[],
@@ -19,6 +25,7 @@ export interface Library<T extends Listable> {
     listing: Listing<T>,
     newListable: T
   ) => Promise<Listing<T>>;
+  UpdateListings: (updates: ListingUpdate<T>[]) => Promise<void>;
   GetOrCreateListingById: (
     listingId: string,
     template?: T
@@ -182,6 +189,42 @@ export function useLibrary<T extends Listable>(
 
   const GetAllListings = React.useCallback(() => [...listings], [listings]);
 
+  /**
+   * Applies every requested update.
+   * Logs every rejected update, then rejects if any update failed.
+   */
+  const UpdateListings = React.useCallback(
+    async (updates: ListingUpdate<T>[]) => {
+      // TODO(encounter-rename-persistence): SaveEditedListing can delete source
+      // account/local representations before the replacement save completes.
+      // It also leaves a local listing in the in-memory array before
+      // saveListing appends the same object again; storage still has one value
+      // because Store.Save overwrites the stable ID. We can replace array entries
+      // instead of appending.
+      const results = await Promise.allSettled(
+        updates.map(update => SaveEditedListing(update.listing, update.value))
+      );
+      const errorsCount = results
+        .filter(result => result.status === "rejected")
+        .reduce((count, result: PromiseRejectedResult) => {
+          console.error("Listing update error", result.reason);
+          return count+1
+        }, 0);
+
+      // SaveEditedListing mutates each Knockout-backed Listing in place, so
+      // React does not see a new listings value. Copy the array to rebuild
+      // consumers such as the path-derived folder tree with the updated meta.
+      setListings(currentListings => [...currentListings]);
+
+      if (errorsCount > 0) {
+        throw new Error(
+            `Could not update ${errorsCount} of ${updates.length} listings.`
+          );
+      }
+    },
+    [SaveEditedListing, setListings]
+  );
+
   // Effects
   if (callbacks.signalLoadComplete) {
     React.useEffect(() => {
@@ -210,6 +253,7 @@ export function useLibrary<T extends Listable>(
     DeleteListing,
     SaveNewListing,
     SaveEditedListing,
+    UpdateListings,
     GetOrCreateListingById,
     GetAllListings
   } as const;

--- a/lesscss/components/libraries.less
+++ b/lesscss/components/libraries.less
@@ -21,6 +21,16 @@
   padding-right: @small-spacer;
 }
 
+/* For showing inline inputs error */
+.tippy-box[data-theme~="error-message"] {
+  background-color: var(--dark-red);
+  color: var(--white);
+
+  > .tippy-arrow {
+      color: var(--dark-red);
+    }
+}
+
 .c-listing-indicator {
   min-width: 38px;
   text-align: center;

--- a/lesscss/components/listing.less
+++ b/lesscss/components/listing.less
@@ -43,7 +43,8 @@
     opacity: 0;
   }
 
-  &:hover {
+  &:hover,
+  &:focus-within {
     .c-listing-boss,
     .c-listing-minion,
     .c-listing-delete,


### PR DESCRIPTION
Hey! As I was rearranging my prepared encounters, I found that I often want to just rename them or folders, without going through editing. Thus, this PR :)

I also want to look into drag-n-drop for moving saved encounters between folders.

## Summary

The PR adds inline rename for saved encounters and encounter folders in the Library’s Encounters pane.

- Enter saves the changes; Escape or blur cancels.
- Collisions are rejected without overwriting data.
- Matching Save Encounter defaults are updated after successful renames.

<img width="350" alt="image" src="https://github.com/user-attachments/assets/2f5ea5a0-5864-4193-a6bd-b912ce94a3f9" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/6c666a62-0b7a-4589-a7c4-3ef77435eafd" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/5b5901d2-085a-4a77-851c-ab3b9d521c43" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/fe07fd42-90ba-41d4-8c70-21aa16c8a03c" />



## Limitations and follow-ups

- Rename is currently enabled only for Encounters.
- Renamed folders close because the path-keyed tree is rebuilt - want to work on that next.
- `UpdateListings` currently reuses legacy append-based persistence; duplicate in-memory rows are filtered from the UI. Didn't want to blow up the PR size; might take a look in the future.
- Might make sense to add collision checks later to ther pre-existing save and move flows.

## Manual testing matrix

The cases are also covered by unit tests.
**Caveat:** tested only in Google Chrome and only in Local Storage mode.

- [x] Hover encounter actions.  
      Rename, Delete, and Move tooltips appear with consistent icon placement.
- [x] Rename an encounter and press Enter.  
      The new name appears immediately and the encounter still loads correctly.
- [x] Start renaming, then press Escape.  
      The original name remains unchanged.
- [x] Start renaming, then click away.  
      The original name remains unchanged.
- [x] Enter an empty name or a name already used in the same folder.  
      A red error popup appears, editing remains active, and nothing is overwritten.
- [x] Use a name that exists in a different folder.  
      The rename succeeds.
- [x] Rename a folder containing nested folders and encounters.  
      All descendants appear under the renamed path with their contents intact.
- [x] Rename a folder to an occupied name or include `/`.  
      The rename is rejected and the original tree remains intact.
- [x] Load an encounter, rename it or its folder, then open Save Current Encounter.  
      The form defaults reflect the successful rename.
- [x] Reload after successful renames while signed out.  
      Names and paths persist without visible duplicate rows.
- [ ] Repeat persistence testing while signed in, if available.  
      Account-backed encounters remain correct after reload.
- [x] Check the other Library panes.  
      Existing behavior remains unchanged and rename is not offered.

Lemme know what you think! Cheers! 