### PR TITLE
Add prompt "Close" and "Close all" controls

### DIFF
--- a/client/Components/Button.tsx
+++ b/client/Components/Button.tsx
@@ -11,6 +11,7 @@ export interface ButtonProps {
   text?: string;
   tooltip?: string;
   tooltipProps?: Omit<TippyProps, "children" | "content">;
+  ariaLabel?: string;
 
   type?: "button" | "submit";
   disabled?: boolean;
@@ -39,6 +40,7 @@ export function Button(props: ButtonProps): JSX.Element {
     <button
       type={props.type ?? "button"}
       className={classNames.join(" ")}
+      aria-label={props.ariaLabel}
       onClick={props.disabled ? undefined : props.onClick}
       onMouseOver={props.disabled ? undefined : props.onMouseOver}
       tabIndex={props.disabled ? -1 : 0}

--- a/client/Prompts/CombatStatsPrompt.tsx
+++ b/client/Prompts/CombatStatsPrompt.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
 
 import { CombatStats } from "../../common/CombatStats";
-import { SubmitButton } from "../Components/Button";
 import { GetTimerReadout } from "../Widgets/GetTimerReadout";
 import { PromptProps } from "./PendingPrompts";
 
-export const CombatStatsPrompt = (stats: CombatStats): PromptProps<{}> => {
+export const CombatStatsPrompt = (
+  stats: CombatStats
+): PromptProps<object> => {
   const totalPlayerTime = stats.combatants
     .map(c => c.elapsedSeconds)
     .reduce((total, curr) => total + curr, 0);
@@ -22,7 +23,6 @@ export const CombatStatsPrompt = (stats: CombatStats): PromptProps<{}> => {
       <div className="combat-stats">
         <div className="combat-stats__header">
           <h4>Post-Combat Breakdown</h4>
-          <SubmitButton />
         </div>
         <ul className={"playercharacters"}>
           {stats.combatants.map((c, index) => (

--- a/client/Prompts/ConditionReferencePrompt.tsx
+++ b/client/Prompts/ConditionReferencePrompt.tsx
@@ -3,11 +3,10 @@ import { Conditions2025 } from "../Rules/Conditions";
 import * as _ from "lodash";
 
 import { PromptProps } from "./PendingPrompts";
-import { SubmitButton } from "../Components/Button";
 
 export function ConditionReferencePrompt(
   conditionName: string
-): PromptProps<{}> | null {
+): PromptProps<object> | null {
   const casedConditionName = _.startCase(conditionName);
   const conditionReference = Conditions2025[casedConditionName];
   if (conditionReference === undefined) {
@@ -24,7 +23,6 @@ export function ConditionReferencePrompt(
             }}
           />
         </div>
-        <SubmitButton />
       </div>
     ),
     autoFocusSelector: "button",

--- a/client/Prompts/LinkInitiativePrompt.tsx
+++ b/client/Prompts/LinkInitiativePrompt.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
 import { PromptProps } from "./PendingPrompts";
-import { SubmitButton } from "../Components/Button";
 import { StandardPromptLayout } from "./StandardPromptLayout";
 
-export function LinkInitiativePrompt(onDismiss: () => void): PromptProps<{}> {
+export function LinkInitiativePrompt(
+  onDismiss: () => void
+): PromptProps<Record<string, never>> {
   return {
     children: (
       <StandardPromptLayout
@@ -17,11 +18,12 @@ export function LinkInitiativePrompt(onDismiss: () => void): PromptProps<{}> {
         }
         fieldsDoSubmit
       >
-        <SubmitButton fontAwesomeIcon="times" />
+        {null}
       </StandardPromptLayout>
     ),
-    autoFocusSelector: "button",
+    autoFocusSelector: ".prompt__close",
     initialValues: {},
+    onDismiss,
     onSubmit: () => {
       onDismiss();
       return true;

--- a/client/Prompts/PendingPrompts.test.tsx
+++ b/client/Prompts/PendingPrompts.test.tsx
@@ -1,0 +1,160 @@
+import { fireEvent, render, waitFor, within } from "@testing-library/react";
+import * as React from "react";
+
+import { LinkInitiativePrompt } from "./LinkInitiativePrompt";
+import { PendingPrompts, PromptProps } from "./PendingPrompts";
+
+type DismissiblePromptProps = PromptProps<Record<string, never>> & {
+  onDismiss?: () => void;
+};
+
+function MockPrompt(
+  overrides: Partial<DismissiblePromptProps> = {}
+): DismissiblePromptProps {
+  return {
+    autoFocusSelector: ".does-not-exist",
+    children: <span>Prompt content</span>,
+    initialValues: {},
+    onSubmit: jest.fn(() => true),
+    ...overrides
+  };
+}
+
+function RenderPrompts(
+  promptsAndIds: [PromptProps<any>, string][],
+  removePrompt = jest.fn()
+) {
+  return {
+    ...render(
+      <PendingPrompts
+        promptsAndIds={promptsAndIds}
+        removePrompt={removePrompt}
+      />
+    ),
+    removePrompt
+  };
+}
+
+describe("PendingPrompts", () => {
+  test("closes one prompt without submitting it", () => {
+    const prompt = MockPrompt();
+    const rendered = RenderPrompts([[prompt, "first-prompt"]]);
+    const closeButton = rendered.getByRole("button", { name: "Close" });
+
+    expect(closeButton.getAttribute("type")).toBe("button");
+    expect(rendered.queryByRole("button", { name: "Close all" })).toBeNull();
+
+    fireEvent.click(closeButton);
+
+    expect(rendered.removePrompt).toHaveBeenCalledWith("first-prompt");
+    expect(prompt.onSubmit).not.toHaveBeenCalled();
+  });
+
+  test("shows Close all on every prompt when several are open", () => {
+    const rendered = RenderPrompts([
+      [MockPrompt(), "first-prompt"],
+      [MockPrompt(), "second-prompt"]
+    ]);
+    const promptForms =
+      rendered.container.querySelectorAll<HTMLFormElement>("form.prompt");
+
+    expect(
+      within(promptForms[0]).getByRole("button", { name: "Close all" })
+    ).toBeTruthy();
+    expect(
+      within(promptForms[1]).getByRole("button", { name: "Close all" })
+    ).toBeTruthy();
+    expect(rendered.getAllByRole("button", { name: "Close all" })).toHaveLength(
+      2
+    );
+  });
+
+  test("closes the current prompt snapshot without submitting any prompt", () => {
+    const promptsAndIds: [DismissiblePromptProps, string][] = [];
+    const firstPrompt = MockPrompt({
+      onDismiss: () => promptsAndIds.splice(1, 1)
+    });
+    const secondPrompt = MockPrompt();
+    promptsAndIds.push(
+      [firstPrompt, "first-prompt"],
+      [secondPrompt, "second-prompt"]
+    );
+    const rendered = RenderPrompts(promptsAndIds);
+
+    fireEvent.click(rendered.getAllByRole("button", { name: "Close all" })[0]);
+
+    expect(rendered.removePrompt.mock.calls).toEqual([
+      ["first-prompt"],
+      ["second-prompt"]
+    ]);
+    expect(firstPrompt.onSubmit).not.toHaveBeenCalled();
+    expect(secondPrompt.onSubmit).not.toHaveBeenCalled();
+  });
+
+  test("uses the same dismissal callback for Close and Escape", () => {
+    const closeDismiss = jest.fn();
+    const escapeDismiss = jest.fn();
+    const rendered = RenderPrompts([
+      [MockPrompt({ onDismiss: closeDismiss }), "close-prompt"],
+      [MockPrompt({ onDismiss: escapeDismiss }), "escape-prompt"]
+    ]);
+    const promptForms =
+      rendered.container.querySelectorAll<HTMLFormElement>("form.prompt");
+
+    fireEvent.click(
+      within(promptForms[0]).getByRole("button", { name: "Close" })
+    );
+    fireEvent.keyUp(promptForms[1], { key: "Escape" });
+
+    expect(closeDismiss).toHaveBeenCalledTimes(1);
+    expect(escapeDismiss).toHaveBeenCalledTimes(1);
+    expect(rendered.removePrompt.mock.calls).toEqual([
+      ["close-prompt"],
+      ["escape-prompt"]
+    ]);
+  });
+
+  test("removes Close all when only one prompt remains", () => {
+    const firstPrompt = MockPrompt();
+    const secondPrompt = MockPrompt();
+    const rendered = RenderPrompts([
+      [firstPrompt, "first-prompt"],
+      [secondPrompt, "second-prompt"]
+    ]);
+
+    rendered.rerender(
+      <PendingPrompts
+        promptsAndIds={[[firstPrompt, "first-prompt"]]}
+        removePrompt={rendered.removePrompt}
+      />
+    );
+
+    expect(rendered.queryByRole("button", { name: "Close all" })).toBeNull();
+  });
+
+  test("clears Link Initiative state through the shared Close control", () => {
+    const clearPendingLink = jest.fn();
+    const prompt = LinkInitiativePrompt(clearPendingLink);
+    const rendered = RenderPrompts([[prompt, "link-prompt"]]);
+
+    fireEvent.click(rendered.getByRole("button", { name: "Close" }));
+
+    expect(clearPendingLink).toHaveBeenCalledTimes(1);
+    expect(rendered.removePrompt).toHaveBeenCalledWith("link-prompt");
+  });
+
+  test("clears Link Initiative state when the prompt is submitted", async () => {
+    const clearPendingLink = jest.fn();
+    const prompt = LinkInitiativePrompt(clearPendingLink);
+    const rendered = RenderPrompts([[prompt, "link-prompt"]]);
+
+    fireEvent.submit(
+      rendered.container.querySelector<HTMLFormElement>("form")!
+    );
+
+    await waitFor(() => {
+      expect(clearPendingLink).toHaveBeenCalledTimes(1);
+      expect(rendered.removePrompt).toHaveBeenCalledWith("link-prompt");
+    });
+  });
+});

--- a/client/Prompts/PendingPrompts.test.tsx
+++ b/client/Prompts/PendingPrompts.test.tsx
@@ -1,8 +1,13 @@
 import { fireEvent, render, waitFor, within } from "@testing-library/react";
 import * as React from "react";
 
+import { Spell } from "../../common/Spell";
+import { Listing } from "../Library/Listing";
+import { CombatStatsPrompt } from "./CombatStatsPrompt";
+import { ConditionReferencePrompt } from "./ConditionReferencePrompt";
 import { LinkInitiativePrompt } from "./LinkInitiativePrompt";
 import { PendingPrompts, PromptProps } from "./PendingPrompts";
+import { SpellPrompt } from "./SpellPrompt";
 
 type DismissiblePromptProps = PromptProps<Record<string, never>> & {
   onDismiss?: () => void;
@@ -50,7 +55,7 @@ describe("PendingPrompts", () => {
     expect(prompt.onSubmit).not.toHaveBeenCalled();
   });
 
-  test("shows Close all on every prompt when several are open", () => {
+  test("shows Close all only on the first prompt when several are open", () => {
     const rendered = RenderPrompts([
       [MockPrompt(), "first-prompt"],
       [MockPrompt(), "second-prompt"]
@@ -62,10 +67,10 @@ describe("PendingPrompts", () => {
       within(promptForms[0]).getByRole("button", { name: "Close all" })
     ).toBeTruthy();
     expect(
-      within(promptForms[1]).getByRole("button", { name: "Close all" })
-    ).toBeTruthy();
+      within(promptForms[1]).queryByRole("button", { name: "Close all" })
+    ).toBeNull();
     expect(rendered.getAllByRole("button", { name: "Close all" })).toHaveLength(
-      2
+      1
     );
   });
 
@@ -81,7 +86,7 @@ describe("PendingPrompts", () => {
     );
     const rendered = RenderPrompts(promptsAndIds);
 
-    fireEvent.click(rendered.getAllByRole("button", { name: "Close all" })[0]);
+    fireEvent.click(rendered.getByRole("button", { name: "Close all" }));
 
     expect(rendered.removePrompt.mock.calls).toEqual([
       ["first-prompt"],
@@ -130,6 +135,40 @@ describe("PendingPrompts", () => {
     );
 
     expect(rendered.queryByRole("button", { name: "Close all" })).toBeNull();
+  });
+
+  test("informational prompts rely on the shared Close control", () => {
+    const spell = { ...Spell.Default(), Name: "Fireball" };
+    const spellListing = new Listing<Spell>(
+      {
+        Id: spell.Id,
+        Link: "",
+        Name: spell.Name,
+        SearchHint: "",
+        FilterDimensions: {},
+        Path: "",
+        LastUpdateMs: 0
+      },
+      "localStorage",
+      spell
+    );
+    const rendered = RenderPrompts([
+      [
+        CombatStatsPrompt({
+          combatants: [],
+          elapsedRounds: 1,
+          elapsedSeconds: 1
+        }),
+        "combat-stats"
+      ],
+      [ConditionReferencePrompt("Prone")!, "condition-reference"],
+      [SpellPrompt(spellListing), "spell-reference"]
+    ]);
+
+    expect(
+      rendered.container.querySelectorAll("button[type='submit']")
+    ).toHaveLength(0);
+    expect(rendered.getAllByRole("button", { name: "Close" })).toHaveLength(3);
   });
 
   test("clears Link Initiative state through the shared Close control", () => {

--- a/client/Prompts/PendingPrompts.tsx
+++ b/client/Prompts/PendingPrompts.tsx
@@ -112,11 +112,11 @@ export class PendingPrompts extends React.Component<PendingPromptsProps> {
   public render() {
     const emptyClassName =
       this.props.promptsAndIds.length == 0 ? " empty" : " tutorial-focus";
+    const canCloseAll = this.props.promptsAndIds.length > 1;
     return (
       <div className={"prompts" + emptyClassName}>
-        {this.props.promptsAndIds.map(promptAndId => {
+        {this.props.promptsAndIds.map((promptAndId, promptIndex) => {
           const [prompt, promptId] = promptAndId;
-          const canCloseAll = this.props.promptsAndIds.length > 1;
 
           return (
             <Prompt
@@ -132,7 +132,11 @@ export class PendingPrompts extends React.Component<PendingPromptsProps> {
               onCancel={() => {
                 this.dismissPrompt(prompt, promptId);
               }}
-              onCancelAll={canCloseAll ? this.dismissAllPrompts : undefined}
+              onCancelAll={
+                promptIndex == 0 && canCloseAll
+                  ? this.dismissAllPrompts
+                  : undefined
+              }
             />
           );
         })}

--- a/client/Prompts/PendingPrompts.tsx
+++ b/client/Prompts/PendingPrompts.tsx
@@ -1,8 +1,10 @@
 import { Formik, FormikProps } from "formik";
 import * as React from "react";
+import { Button } from "../Components/Button";
 
 export interface PromptProps<T extends object> {
   onSubmit: (submittedValues: T) => boolean;
+  onDismiss?: () => void;
   children: React.ReactChild;
   autoFocusSelector: string;
   initialValues: T;
@@ -11,9 +13,10 @@ export interface PromptProps<T extends object> {
 class Prompt<T extends object> extends React.Component<
   PromptProps<T> & {
     onCancel: () => void;
+    onCancelAll?: () => void;
   }
 > {
-  private formElement: HTMLFormElement;
+  private formElement: HTMLFormElement | null = null;
 
   public render() {
     return (
@@ -35,6 +38,25 @@ class Prompt<T extends object> extends React.Component<
             }}
           >
             {this.props.children}
+            <div className="prompt__utility-controls">
+              {this.props.onCancelAll && (
+                <Button
+                  additionalClassNames="prompt__dismiss prompt__close-all"
+                  ariaLabel="Close all"
+                  fontAwesomeIcon="times"
+                  onClick={this.props.onCancelAll}
+                  text="All"
+                  tooltip="Close all"
+                />
+              )}
+              <Button
+                additionalClassNames="prompt__dismiss prompt__close"
+                ariaLabel="Close"
+                fontAwesomeIcon="times"
+                onClick={this.props.onCancel}
+                tooltip="Close"
+              />
+            </div>
           </form>
         )}
       </Formik>
@@ -51,7 +73,7 @@ class Prompt<T extends object> extends React.Component<
     }
 
     //prevent mounted element from swallowing hotkey
-    const element: HTMLInputElement = this.formElement.querySelector(
+    const element = this.formElement.querySelector<HTMLInputElement>(
       this.props.autoFocusSelector
     );
 
@@ -69,11 +91,24 @@ class Prompt<T extends object> extends React.Component<
 }
 
 interface PendingPromptsProps {
-  promptsAndIds: [PromptProps<object>, string][];
+  promptsAndIds: [PromptProps<any>, string][];
   removePrompt: (promptId: string) => void;
 }
 
 export class PendingPrompts extends React.Component<PendingPromptsProps> {
+  private dismissPrompt = (prompt: PromptProps<any>, promptId: string) => {
+    if (prompt.onDismiss) {
+      prompt.onDismiss();
+    }
+    this.props.removePrompt(promptId);
+  };
+
+  private dismissAllPrompts = () => {
+    this.props.promptsAndIds
+      .slice()
+      .forEach(([prompt, promptId]) => this.dismissPrompt(prompt, promptId));
+  };
+
   public render() {
     const emptyClassName =
       this.props.promptsAndIds.length == 0 ? " empty" : " tutorial-focus";
@@ -81,6 +116,7 @@ export class PendingPrompts extends React.Component<PendingPromptsProps> {
       <div className={"prompts" + emptyClassName}>
         {this.props.promptsAndIds.map(promptAndId => {
           const [prompt, promptId] = promptAndId;
+          const canCloseAll = this.props.promptsAndIds.length > 1;
 
           return (
             <Prompt
@@ -94,8 +130,9 @@ export class PendingPrompts extends React.Component<PendingPromptsProps> {
                 return shouldResolve;
               }}
               onCancel={() => {
-                this.props.removePrompt(promptId);
+                this.dismissPrompt(prompt, promptId);
               }}
+              onCancelAll={canCloseAll ? this.dismissAllPrompts : undefined}
             />
           );
         })}

--- a/client/Prompts/SpellPrompt.tsx
+++ b/client/Prompts/SpellPrompt.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 
 import { Spell } from "../../common/Spell";
-import { SubmitButton } from "../Components/Button";
 import { SpellDetails } from "../Library/Components/SpellDetails";
 import { PromptProps } from "./PendingPrompts";
 import { Listing } from "../Library/Listing";
@@ -30,7 +29,6 @@ function SpellPromptComponent(props: {
           <h3>{props.spellListing.Meta().Name}</h3>
           <p>Error loading spell: {error}</p>
         </div>
-        <SubmitButton />
       </div>
     );
   }
@@ -42,7 +40,6 @@ function SpellPromptComponent(props: {
           <h3>{props.spellListing.Meta().Name}</h3>
           <p>Loading...</p>
         </div>
-        <SubmitButton />
       </div>
     );
   }
@@ -50,9 +47,6 @@ function SpellPromptComponent(props: {
   return (
     <div className="prompt-spell">
       <SpellDetails Spell={spell} />
-      <SubmitButton />
     </div>
   );
 }
-
-

--- a/client/TrackerViewModel.tsx
+++ b/client/TrackerViewModel.tsx
@@ -18,7 +18,6 @@ import { EncounterCommander } from "./Commands/EncounterCommander";
 import { LibrariesCommander } from "./Commands/LibrariesCommander";
 import { PrivacyPolicyPrompt } from "./Prompts/PrivacyPolicyPrompt";
 import { PromptQueue } from "./Commands/PromptQueue";
-import { SubmitButton } from "./Components/Button";
 import { Encounter } from "./Encounter/Encounter";
 import { UpdateLegacyEncounterState } from "./Encounter/UpdateLegacySavedEncounter";
 import { env } from "./Environment";
@@ -260,7 +259,6 @@ export class TrackerViewModel {
               Patreon
             </a>
             {" to use the D&D Beyond Importer."}
-            <SubmitButton />
           </span>
         )
       });
@@ -289,7 +287,6 @@ export class TrackerViewModel {
               Epic Initiative
             </a>
             {" Patrons."}
-            <SubmitButton />
           </span>
         )
       });

--- a/lesscss/components/prompts.less
+++ b/lesscss/components/prompts.less
@@ -24,6 +24,41 @@
   align-items: flex-start;
   justify-content: space-between;
   min-height: @prompt-minimum-height;
+  position: relative;
+
+  .prompt__utility-controls {
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    right: -@small-spacer * 2;
+    transform: translateY(-50%);
+    flex-flow: row nowrap;
+  }
+
+  button.prompt__dismiss {
+    .colors(var(--text), var(--input-bg), var(--dark-border));
+    min-width: 1.3rem;
+    min-height: 1.3rem;
+    margin: 0;
+    padding: @extra-small-spacer;
+    font-size: 12px;
+    box-shadow:
+      0 0 5px rgba(0, 0, 0, 0.3),
+      0 4px 5px rgba(0, 0, 0, 0.28);
+
+    &:hover {
+      .colors(var(--text-inverted), var(--dark-red), var(--dark-red));
+    }
+  }
+
+  button.prompt__close-all {
+    padding-right: @small-spacer;
+    padding-left: @small-spacer;
+  }
+
+  button.prompt__close {
+    margin-left: @medium-spacer;
+  }
 
   div,
   p,

--- a/thanks.ts
+++ b/thanks.ts
@@ -51,5 +51,10 @@ export default [
     Name: "Nate Whittington",
     Github: "https://github.com/bluecliffadventures",
     PatreonId: "4000000"
+  },
+  {
+    Name: "Captain Solo",
+    Github: "https://github.com/treble-snake",
+    PatreonId: "97276950"
   }
 ];


### PR DESCRIPTION
Hi! Another small QoL PR, which also resolves #653

**Note:** developed with AI assistance, but fully proof-read, refactored and tested personally.

## Summary

Adds compact buttons for closing combat prompts:

- A compact `[×]` control on every prompt to close it.
- A compact `[ × All ]` control on every prompt when multiple prompts are open to close all prompts.
- Close, Escape, and Close All use the same dismissal lifecycle.

## Motivation

For "Close All" - described in the related issue #653.
For "Close" - now some prompts can only be dismissed with the Esc key. If you click away and they lose focus, you have to click back to an input and then press Esc to close them.

## Visuals

Single prompt:
<img width="807" alt="image" src="https://github.com/user-attachments/assets/b0a3cdc0-8b9b-4b8d-942c-d0bac1a93010" />

Single prompt, hover:
<img width="807" alt="image" src="https://github.com/user-attachments/assets/ef21abfe-9478-499d-b903-4bdc788902ff" />

Multiple prompts (outdated, switched to only one button):
<img width="807" alt="image" src="https://github.com/user-attachments/assets/b6962a5c-c9c6-4d24-b03a-c0054cfea413" />

Multiple prompts, only one "Close all" on top:
<img width="809" height="777" alt="image" src="https://github.com/user-attachments/assets/d5e91e85-9713-45fd-b5ca-b0d6ee2d8776" />

"Close all" hover:
<img width="807" alt="image" src="https://github.com/user-attachments/assets/b611ca80-63f6-4560-ac81-2f22e1d93e01" />

Dark mode:
<img width="813" height="457" alt="image" src="https://github.com/user-attachments/assets/491ed510-b990-42ac-8443-76faef051643" />

Narrow layout:
<img width="476" height="484" alt="image" src="https://github.com/user-attachments/assets/cd10ef6c-70fa-40cf-bed9-57e0da6642e1" />


## Manual QA

Unit tests attached, and these are also checked manually:

- [x] Open one prompt and confirm only the compact × control is visible.
- [x] Confirm the × is centered over the prompt’s top border and does not cover prompt content.
- [x] Hover the × and confirm the tooltip reads “Close.”
- [x] Close a prompt with × and confirm its action is not submitted.
- [x] Focus a prompt and confirm Escape still closes it.
- [x] Open two prompts and confirm both display × All and × controls.
- [x] Close one prompt and confirm the remaining prompt immediately loses its × All control.
- [x] Open three prompts, click × All on the first or middle prompt, and confirm every currently open prompt closes.
- [x] Confirm the × All tooltip reads “Close all.”
- [x] Start Link Initiative with one selected combatant, close its prompt, then select another combatant and confirm they are not linked.
- [x] Start Link Initiative again, select a second combatant normally, and confirm linking still completes and removes the prompt.
- [x] Submit a normal prompt such as Quick Add and confirm its existing submit behaviour is unchanged.
- [x] Check the controls in both light and dark modes.
- [x] Check a narrow layout and confirm the controls remain visible without adding horizontal or vertical prompt space.

Lemme know what'ya think! Happy to tweak the visuals or anything else :)

Cheers! ✌️ 