### PR TITLE
Convert to Nimble system: hide D&D-only fields, add Mana resource

### DIFF
--- a/NIMBLE-CONVERSION-PLAN.md
+++ b/NIMBLE-CONVERSION-PLAN.md
@@ -1,0 +1,107 @@
+# Mana Tracking Plan
+
+Goal: add a "Mana" resource that behaves like Hit Points — trackable per-combatant
+during combat, with a max value on the stat block and a current value that goes up
+and down during an encounter, shown in the UI wherever HP already shows.
+
+## How HP actually works (for reference)
+
+HP isn't one field — it's a template value plus a separate combat-instance value,
+wired through four layers:
+
+1. **Template (max/base)**: `StatBlock.HP: { Value: number; Notes: string }`
+   (`common/StatBlock.ts`) — the reusable creature/character definition.
+2. **Combat instance (current)**: `CombatantState.CurrentHP` and `.TemporaryHP`
+   (`common/CombatantState.ts`) — per-encounter, persisted separately from the
+   template. `Combatant.ts` holds these as Knockout observables (`CurrentHP`,
+   `TemporaryHP`), and derives `MaxHP` live from the current StatBlock rather than
+   storing it twice.
+3. **Prompts/commands**: `ApplyDamagePrompt.tsx` / `ApplyHealingPrompt.tsx` /
+   `ApplyTemporaryHPPrompt.tsx` (UI) → `CombatantCommander` methods (`ApplyDamage`,
+   `ApplyHealing`, `AddTemporaryHP`) → `Combatant.ApplyDamage`/`ApplyHealing`/
+   `ApplyTemporaryHP` (the actual clamping/math) → `CombatantViewModel` wraps this
+   for the React/Knockout bridge and fires concentration checks + event log entries.
+4. **Display**: the initiative list row (colored HP cell + optional bar), the
+   combatant detail panel ("Current HP"), the stat block display/editor (base HP),
+   and Player View (HP hidden/shown/colored per a verbosity setting, since players
+   shouldn't always see exact enemy HP).
+
+`TemporaryHP` is the closest existing precedent for a second HP-like pool — it's
+additive and absorbs damage first, though Mana more likely wants its own
+independent current/max pool (closer to how CurrentHP+MaxHP works than how
+TemporaryHP works).
+
+## Decisions needed before implementing
+
+1. **Does every stat block get Mana, or only some?** Not every Nimble creature/class
+   necessarily uses mana. Recommend making it optional (`Mana?: { Value: number;
+   Notes: string }` on `StatBlock`) so it can be omitted, with the UI only showing
+   the Mana row/field when it's present — same idea as how `Speed` is now hidden
+   when empty.
+2. **How deep should this go on the first pass?** HP has a full stack: prompts,
+   commands, keybindings, initiative-list click-to-edit, colored bars, Player View
+   verbosity settings, event log entries. Suggest building this in phases (below)
+   rather than the full stack at once — confirm which phase to stop at for now.
+3. **Does Mana need a "temporary mana" equivalent?** (Skipping unless you want it —
+   adds complexity for a mechanic that may not exist in Nimble.)
+4. **Should current Mana persist across encounters for player characters**, the way
+   `PersistentCharacter.CurrentHP` does? (Relevant if the same PC is reused in
+   multiple fights in one session.)
+
+## Proposed phases
+
+### Phase 1 — Data model + stat block editor + template display only
+No combat tracking yet, just defining and viewing max Mana on a stat block.
+- `common/StatBlock.ts`: add `Mana?: ValueAndNotes` to `StatBlock`.
+- `client/StatBlockEditor/StatBlockEditor.tsx`: add a `ValueAndNotesField`
+  (already generic, used by HP/AC) for `fieldName="Mana"`.
+- `client/Components/StatBlock.tsx`: show Mana in the stat block display panel
+  (conditionally, only when `statBlock.Mana` is set), consistent with how
+  HP/Defense/Speed are shown now.
+
+### Phase 2 — Current Mana tracked per-combatant during an encounter
+Makes Mana a real "goes up and down in combat" resource, not just a static number.
+- `common/CombatantState.ts`: add `CurrentMana?: number`.
+- `client/Combatant/Combatant.ts`: add `CurrentMana` observable, `MaxMana` computed
+  (derived from StatBlock, like `MaxHP`), hydrate/serialize in
+  `processCombatantState`/`GetState`.
+- `client/Encounter/Encounter.ts` (`AddCombatantFromStatBlock`,
+  `AddCombatantFromPersistentCharacter`) and
+  `client/Reducers/InitializeCombatantFromStatBlock.tsx`: seed `CurrentMana` when a
+  combatant is added.
+- `client/Encounter/UpdateLegacySavedEncounter.ts`: default `CurrentMana` for
+  encounters saved before this existed.
+- `client/Combatant/CombatantDetails.tsx`: show "Current Mana" next to "Current HP"
+  (still just a display, not yet editable via a dedicated prompt).
+
+### Phase 3 — Spend/restore mechanics (the "apply damage" equivalent)
+- `Combatant.ts`: `ApplySpendMana(amount)` / `ApplyRestoreMana(amount)`, clamped
+  0..max (mirrors `ApplyDamage`/`ApplyHealing`).
+- New prompt(s) modeled on `ApplyDamagePrompt.tsx`/`ApplyHealingPrompt.tsx`.
+- `CombatantCommander.tsx`: `SpendMana`/`RestoreMana` methods enqueuing the prompt.
+- `BuildCombatantCommandList.ts`: register as commands (toolbar/keybind/context
+  menu), same pattern as "Apply Damage"/"Apply Healing".
+- `EventLog`: log mana changes, same as `LogHPChange`.
+
+### Phase 4 — Initiative list + Player View parity
+Only worth doing once Phase 3 is confirmed useful in practice.
+- `client/InitiativeList/CombatantRow.tsx`: a Mana cell (colored bar, click-to-spend)
+  alongside the HP cell.
+- Player View: `ToPlayerViewCombatantState.ts` + a Mana verbosity setting, mirroring
+  `MonsterHPVerbosity`/`PlayerHPVerbosity`, if players should see (or not see) enemy
+  mana.
+
+## Recommendation
+
+Start with **Phase 1** to confirm the field/label/shape feels right, then decide
+whether to continue into Phase 2+. This matches how the ability-score and stat
+label changes have gone so far — small, reviewable steps rather than the whole
+stack at once.
+
+## Review checklist
+
+- [ ] Confirm Mana should be optional per stat block (not forced on every creature).
+- [ ] Pick a stopping phase for the first implementation pass.
+- [ ] Confirm/deny "temporary mana."
+- [ ] Confirm/deny cross-encounter persistence for player characters.
+- [ ] Any naming preference — "Mana", "MP", something else?

--- a/client/Combatant/Combatant.ts
+++ b/client/Combatant/Combatant.ts
@@ -34,6 +34,9 @@ export class Combatant {
 
     this.CurrentHP = ko.observable(combatantState.CurrentHP);
     this.CurrentNotes = ko.observable(combatantState.CurrentNotes || "");
+    this.CurrentMana = ko.observable(
+      combatantState.CurrentMana ?? this.MaxMana() ?? 0
+    );
 
     this.processCombatantState(combatantState);
 
@@ -68,6 +71,7 @@ export class Combatant {
   public CombatTimer = new CombatTimer();
 
   public CurrentHP: KnockoutObservable<number>;
+  public CurrentMana: KnockoutObservable<number>;
   public CurrentNotes: KnockoutObservable<string>;
   public PlayerDisplayHP: KnockoutComputed<string>;
   private updatingGroup = false;
@@ -87,6 +91,7 @@ export class Combatant {
     this.IndexLabel(savedCombatant.IndexLabel || 0);
     this.CurrentHP(savedCombatant.CurrentHP);
     this.CurrentNotes(savedCombatant.CurrentNotes || "");
+    this.CurrentMana(savedCombatant.CurrentMana ?? this.MaxMana() ?? 0);
     this.TemporaryHP(savedCombatant.TemporaryHP);
     this.Initiative(savedCombatant.Initiative);
     this.InitiativeGroup(
@@ -113,6 +118,12 @@ export class Combatant {
     this.CurrentHP.subscribe(async c => {
       return await updatePersistentCharacter(persistentCharacterId, {
         CurrentHP: c
+      });
+    });
+
+    this.CurrentMana.subscribe(async m => {
+      return await updatePersistentCharacter(persistentCharacterId, {
+        CurrentMana: m
       });
     });
 
@@ -173,6 +184,8 @@ export class Combatant {
 
   public MaxHP = ko.computed(() => this.StatBlock().HP.Value);
 
+  public MaxMana = ko.computed(() => this.StatBlock().Mana?.Value);
+
   public GetInitiativeRoll: () => AbilityCheckResult = () => {
     const sideInitiative =
       CurrentSettings().Rules.AutoGroupInitiative ==
@@ -231,6 +244,20 @@ export class Combatant {
     this.CurrentHP(currHP);
   }
 
+  public ApplyManaChange(amount: number) {
+    const maxMana = this.MaxMana() ?? 0;
+    let currentMana = this.CurrentMana() - amount;
+
+    if (currentMana < 0) {
+      currentMana = 0;
+    }
+    if (currentMana > maxMana) {
+      currentMana = maxMana;
+    }
+
+    this.CurrentMana(currentMana);
+  }
+
   public ApplyTemporaryHP(tempHP: number) {
     if (tempHP > this.TemporaryHP()) {
       this.TemporaryHP(tempHP);
@@ -259,6 +286,7 @@ export class Combatant {
       PersistentCharacterId: this.PersistentCharacterId || undefined,
       StatBlock: this.StatBlock(),
       CurrentHP: this.CurrentHP(),
+      CurrentMana: this.CurrentMana(),
       CurrentNotes: this.CurrentNotes(),
       TemporaryHP: this.TemporaryHP(),
       Initiative: this.Initiative(),

--- a/client/Combatant/CombatantDetails.tsx
+++ b/client/Combatant/CombatantDetails.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { StatBlockComponent } from "../Components/StatBlock";
+import { StatBlock } from "../../common/StatBlock";
 import { StatBlockHeader } from "../Components/StatBlockHeader";
 import { TextEnricherContext } from "../TextEnricher/TextEnricher";
 import { CombatantViewModel } from "./CombatantViewModel";
@@ -20,6 +21,10 @@ export function CombatantDetails(props: CombatantDetailsProps): JSX.Element {
   const currentHp = useSubscription(props.combatantViewModel.HP);
   const currentHPPercentage = useSubscription(
     props.combatantViewModel.HPPercentage
+  );
+  const currentMana = useSubscription(props.combatantViewModel.Mana);
+  const currentManaPercentage = useSubscription(
+    props.combatantViewModel.ManaPercentage
   );
   const name = useSubscription(props.combatantViewModel.Name);
   const tags = useSubscription(props.combatantViewModel.Combatant.Tags);
@@ -52,7 +57,7 @@ export function CombatantDetails(props: CombatantDetailsProps): JSX.Element {
         imageUrl={statBlock.ImageURL}
       />
       <div className="c-combatant-details__hp">
-        <span className="stat-label">Current HP</span>
+        <span className="stat-label CurrentHP">HP</span>
         <span>
           {currentHp}
           {DisplayHPBar && (
@@ -64,6 +69,49 @@ export function CombatantDetails(props: CombatantDetailsProps): JSX.Element {
             </span>
           )}
         </span>
+        {currentMana && (
+          <>
+            <span className="stat-label Mana">Mana</span>
+            <span>
+              {currentMana}
+              {DisplayHPBar && (
+                <span className="combatant__hp-bar">
+                  <span
+                    className="combatant__hp-bar--filled"
+                    style={renderHPBarStyle(currentManaPercentage)}
+                  />
+                </span>
+              )}
+            </span>
+          </>
+        )}
+        {statBlock.Challenge && (
+          <>
+            <span className="stat-label Level">
+              {statBlock.Player == "player" ? "Level" : "Challenge"}
+            </span>
+            <span className="stat-value">{statBlock.Challenge}</span>
+          </>
+        )}
+      </div>
+      <div className="HP AC speed Challenge">
+        <span className="stat-label">Defense</span>
+        <span className="stat-value">{statBlock.AC.Value}</span>
+        {statBlock.Speed.length > 0 && (
+          <>
+            <span className="stat-label Speed">Speed</span>
+            <span className="stat-value">
+              {statBlock.Speed.map((speed, i) => (
+                <span
+                  className="stat-value__item"
+                  key={"stat-value__speed-" + i}
+                >
+                  {speed}
+                </span>
+              ))}
+            </span>
+          </>
+        )}
       </div>
       {tags.length > 0 && (
         <div className="c-combatant-details__tags">
@@ -78,11 +126,15 @@ export function CombatantDetails(props: CombatantDetailsProps): JSX.Element {
         </div>
       )}
       {props.displayMode !== "status-only" && (
-        <StatBlockComponent
-          statBlock={statBlock}
-          displayMode={props.displayMode}
-          hideName
-        />
+        <>
+          {StatBlock.IsPlayerCharacter(statBlock) && <hr />}
+          <StatBlockComponent
+            statBlock={statBlock}
+            displayMode={props.displayMode}
+            hideName
+            hideTopRow
+          />
+        </>
       )}
       {renderedNotes && (
         <div className="c-combatant-details__notes">{renderedNotes}</div>

--- a/client/Combatant/CombatantViewModel.ts
+++ b/client/Combatant/CombatantViewModel.ts
@@ -17,6 +17,8 @@ const animatedCombatantIds = ko.observableArray<string>([]);
 export class CombatantViewModel {
   public HP: ko.PureComputed<string>;
   public HPPercentage: ko.PureComputed<string>;
+  public Mana: ko.PureComputed<string>;
+  public ManaPercentage: ko.PureComputed<string>;
   public Name: ko.PureComputed<string>;
 
   constructor(
@@ -37,6 +39,22 @@ export class CombatantViewModel {
         Math.floor(
           (this.Combatant.CurrentHP() / this.Combatant.MaxHP()) * 100
         ) + "%"
+      );
+    });
+    this.Mana = ko.pureComputed(() => {
+      const maxMana = this.Combatant.MaxMana();
+      if (maxMana === undefined) {
+        return null;
+      }
+      return `${this.Combatant.CurrentMana()}/${maxMana}`;
+    });
+    this.ManaPercentage = ko.pureComputed(() => {
+      const maxMana = this.Combatant.MaxMana();
+      if (!maxMana) {
+        return "0%";
+      }
+      return (
+        Math.floor((this.Combatant.CurrentMana() / maxMana) * 100) + "%"
       );
     });
     this.Name = Combatant.DisplayName;
@@ -67,6 +85,15 @@ export class CombatantViewModel {
     } else {
       this.Combatant.ApplyHealing(healing);
     }
+  }
+
+  public ApplyManaChange(inputAmount: string) {
+    const amount = parseInt(inputAmount);
+    if (isNaN(amount)) {
+      return;
+    }
+
+    this.Combatant.ApplyManaChange(amount);
   }
 
   public ApplyTemporaryHP(newTemporaryHP: number) {

--- a/client/Combatant/ToPlayerViewCombatantState.ts
+++ b/client/Combatant/ToPlayerViewCombatantState.ts
@@ -12,6 +12,8 @@ export function ToPlayerViewCombatantState(
     Id: combatant.Id,
     HPDisplay: GetHPDisplay(combatant),
     HPColor: GetHPColor(combatant),
+    ManaDisplay: GetManaDisplay(combatant),
+    ManaColor: GetManaColor(combatant),
     Initiative: combatant.Initiative(),
     IsPlayerCharacter: combatant.IsPlayerCharacter(),
     Tags: combatant
@@ -60,6 +62,57 @@ function GetHPDisplay(combatant: Combatant): string {
     return "<span class='hurtHP'>Hurt</span>";
   }
   return "<span class='healthyHP'>Healthy</span>";
+}
+
+function GetManaDisplay(combatant: Combatant): string | undefined {
+  const maxMana = combatant.MaxMana();
+  if (maxMana === undefined) {
+    return undefined;
+  }
+
+  const manaVerbosity = combatant.IsPlayerCharacter()
+    ? CurrentSettings().PlayerView.PlayerHPVerbosity
+    : CurrentSettings().PlayerView.MonsterHPVerbosity;
+  const currentMana = combatant.CurrentMana();
+  if (manaVerbosity == "Actual HP") {
+    return `${currentMana}/${maxMana}`;
+  }
+  if (manaVerbosity == "Hide All") {
+    return "";
+  }
+  if (manaVerbosity == "Damage Taken") {
+    return (currentMana - maxMana).toString();
+  }
+  if (currentMana <= 0) {
+    return "<span class='defeatedHP'>Empty</span>";
+  } else if (currentMana < maxMana / 2) {
+    return "<span class='bloodiedHP'>Low</span>";
+  } else if (currentMana < maxMana) {
+    return "<span class='hurtHP'>Reduced</span>";
+  }
+  return "<span class='healthyHP'>Full</span>";
+}
+
+function GetManaColor(combatant: Combatant): string | undefined {
+  const maxMana = combatant.MaxMana();
+  if (maxMana === undefined) {
+    return undefined;
+  }
+
+  const manaVerbosity = combatant.IsPlayerCharacter()
+    ? CurrentSettings().PlayerView.PlayerHPVerbosity
+    : CurrentSettings().PlayerView.MonsterHPVerbosity;
+  if (
+    manaVerbosity == "Monochrome Label" ||
+    manaVerbosity == "Hide All" ||
+    manaVerbosity == "Damage Taken"
+  ) {
+    return "auto";
+  }
+  const currentMana = combatant.CurrentMana();
+  const green = Math.floor((currentMana / maxMana) * 170);
+  const red = Math.floor(((maxMana - currentMana) / maxMana) * 170);
+  return "rgb(" + red + "," + green + ",0)";
 }
 
 function GetHPColor(combatant: Combatant) {

--- a/client/Commands/BuildCombatantCommandList.ts
+++ b/client/Commands/BuildCombatantCommandList.ts
@@ -25,6 +25,20 @@ export const BuildCombatantCommandList: (
     defaultShowOnActionBar: false
   }),
   new Command({
+    id: "spend-mana",
+    description: "Spend Mana",
+    actionBinding: c.SpendMana,
+    fontAwesomeIcon: "hat-wizard",
+    defaultShowOnActionBar: false
+  }),
+  new Command({
+    id: "restore-mana",
+    description: "Restore Mana",
+    actionBinding: c.RestoreMana,
+    fontAwesomeIcon: "star",
+    defaultShowOnActionBar: false
+  }),
+  new Command({
     id: "add-tag",
     description: "Add Tag",
     actionBinding: c.AddTag,

--- a/client/Commands/CombatantCommander.tsx
+++ b/client/Commands/CombatantCommander.tsx
@@ -18,6 +18,8 @@ import { AcceptDamagePrompt } from "../Prompts/AcceptDamagePrompt";
 import { AcceptTagPrompt } from "../Prompts/AcceptTagPrompt";
 import { ApplyDamagePrompt } from "../Prompts/ApplyDamagePrompt";
 import { ApplyHealingPrompt } from "../Prompts/ApplyHealingPrompt";
+import { ApplyManaPrompt } from "../Prompts/ApplyManaPrompt";
+import { RestoreManaPrompt } from "../Prompts/RestoreManaPrompt";
 import { ConcentrationPrompt } from "../Prompts/ConcentrationPrompt";
 import { ShowDiceRollPrompt } from "../Prompts/RollDicePrompt";
 import { TagPrompt } from "../Prompts/TagPrompt";
@@ -243,6 +245,41 @@ export class CombatantCommander {
       selectedCombatants,
       latestRollTotal.toString(),
       this.tracker.EventLog.LogHPChange
+    );
+    this.tracker.PromptQueue.Add(prompt);
+  };
+
+  private applyManaForCombatants(combatantViewModels: CombatantViewModel[]) {
+    const prompt = ApplyManaPrompt(
+      combatantViewModels,
+      "",
+      this.tracker.EventLog.LogManaChange
+    );
+    this.tracker.PromptQueue.Add(prompt);
+  }
+
+  public SpendMana = () => {
+    if (!this.HasSelected()) {
+      return;
+    }
+
+    const selectedCombatants = this.SelectedCombatants();
+    this.applyManaForCombatants(selectedCombatants);
+  };
+
+  public SpendManaTargeted = (combatantViewModel: CombatantViewModel) => {
+    this.applyManaForCombatants([combatantViewModel]);
+  };
+
+  public RestoreMana = () => {
+    if (!this.HasSelected()) {
+      return;
+    }
+    const selectedCombatants = this.SelectedCombatants();
+    const prompt = RestoreManaPrompt(
+      selectedCombatants,
+      "",
+      this.tracker.EventLog.LogManaChange
     );
     this.tracker.PromptQueue.Add(prompt);
   };

--- a/client/Components/StatBlock.tsx
+++ b/client/Components/StatBlock.tsx
@@ -8,13 +8,13 @@ import { StatBlockHeader } from "./StatBlockHeader";
 import { useContext } from "react";
 import { LoadingIndicator } from "./LoadingIndicator";
 import ErrorBoundary from "./ErrorBoundary";
-import { DefaultRules } from "../Rules/Rules";
 import { SettingsContext } from "../Settings/SettingsContext";
 
 interface StatBlockProps {
   statBlock: StatBlock;
   displayMode: "default" | "active";
   hideName?: boolean;
+  hideTopRow?: boolean;
   isLoading?: boolean;
 }
 
@@ -38,15 +38,11 @@ export function StatBlockComponent(props: StatBlockProps) {
 
 function StatBlockComponentNoError(props: StatBlockProps) {
   const textEnricher = useContext(TextEnricherContext);
-  const rules = new DefaultRules();
   const settings = useContext(SettingsContext);
 
   const statBlock = props.statBlock;
 
-  const modifierTypes = [
-    { name: "Saves", data: statBlock.Saves },
-    { name: "Skills", data: statBlock.Skills }
-  ];
+  const modifierTypes = [{ name: "Saves", data: statBlock.Saves }];
 
   const keywordSetTypes = [
     { name: "Senses", data: statBlock.Senses },
@@ -77,55 +73,53 @@ function StatBlockComponentNoError(props: StatBlockProps) {
         />
       )}
 
-      <hr />
+      {!props.hideTopRow && <hr />}
     </>
   );
 
   const statEntries = (
     <>
-      <div className="AC">
-        <span className="stat-label">Armor Class</span>
-        <span className="stat-value">{statBlock.AC.Value}</span>
-        <span className="notes">
-          {textEnricher.EnrichText(statBlock.AC.Notes)}
-        </span>
-      </div>
-
-      <div className="HP">
-        <span className="stat-label">Hit Points</span>
-        <span className="stat-value">{statBlock.HP.Value}</span>
-        <span className="notes">
-          {textEnricher.EnrichText(statBlock.HP.Notes)}
-        </span>
-      </div>
-
-      <div className="speed">
-        <span className="stat-label">Speed</span>
-        <span className="stat-value">
-          {statBlock.Speed.map((speed, i) => (
-            <span className="stat-value__item" key={"stat-value__speed-" + i}>
-              {speed}
-            </span>
-          ))}
-        </span>
-      </div>
-
-      <div className="Abilities">
-        {Object.keys(StatBlock.Default().Abilities).map(abilityName => {
-          const abilityScore = statBlock.Abilities[abilityName];
-          const abilityModifier =
-            textEnricher.GetEnrichedModifierFromAbilityScore(abilityScore);
-          return (
-            <div className="Ability" key={abilityName}>
-              <div className="stat-label">{abilityName}</div>
-              <span className={"score " + abilityName}>{abilityScore}</span>
-              <span className={"modifier " + abilityName}>
-                {abilityModifier}
+      {!props.hideTopRow && (
+        <div className="HP AC speed Challenge">
+          <span className="stat-label">Defense</span>
+          <span className="stat-value">{statBlock.AC.Value}</span>
+          {statBlock.Speed.length > 0 && (
+            <>
+              <span className="stat-label Speed">Speed</span>
+              <span className="stat-value">
+                {statBlock.Speed.map((speed, i) => (
+                  <span
+                    className="stat-value__item"
+                    key={"stat-value__speed-" + i}
+                  >
+                    {speed}
+                  </span>
+                ))}
               </span>
-            </div>
-          );
-        })}
-      </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {StatBlock.IsPlayerCharacter(statBlock) && (
+        <div className="Abilities">
+          {StatBlock.VisibleAbilityNames.map(abilityName => {
+            const abilityScore = statBlock.Abilities[abilityName];
+            const abilityModifier =
+              textEnricher.GetEnrichedModifierFromAbilityScore(abilityScore);
+            return (
+              <div className="Ability" key={abilityName}>
+                <div className="stat-label">
+                  {StatBlock.AbilityDisplayNames[abilityName] || abilityName}
+                </div>
+                <span className={"modifier " + abilityName}>
+                  {abilityModifier}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
 
       {settings.StatBlock.CustomFields.length > 0 && (
         <div className="custom-fields">
@@ -144,8 +138,6 @@ function StatBlockComponentNoError(props: StatBlockProps) {
           })}
         </div>
       )}
-
-      <hr />
 
       <div className="modifiers">
         {modifierTypes
@@ -186,19 +178,6 @@ function StatBlockComponentNoError(props: StatBlockProps) {
             </div>
           ))}
       </div>
-
-      {statBlock.Challenge && (
-        <div className="Challenge">
-          <span className="stat-label">
-            {statBlock.Player == "player" ? "Level" : "Challenge"}
-          </span>
-          <span className="stat-value">{statBlock.Challenge}</span>
-          <span className="stat-label">Proficiency Bonus</span>
-          <span className="stat-value">
-            +{rules.GetProficiencyBonus(statBlock.Challenge)}
-          </span>
-        </div>
-      )}
 
       <hr />
     </>

--- a/client/Encounter/Encounter.ts
+++ b/client/Encounter/Encounter.ts
@@ -243,6 +243,7 @@ export class Encounter {
       Alias: "",
       IndexLabel: null,
       CurrentHP: persistentCharacter.CurrentHP,
+      CurrentMana: persistentCharacter.CurrentMana,
       CurrentNotes: persistentCharacter.Notes,
       TemporaryHP: 0,
       Hidden: hideOnAdd,
@@ -446,6 +447,9 @@ export class Encounter {
 
         combatant.StatBlock(persistentCharacter.StatBlock);
         combatant.CurrentHP(persistentCharacter.CurrentHP);
+        combatant.CurrentMana(
+          persistentCharacter.CurrentMana ?? combatant.MaxMana() ?? 0
+        );
         combatant.CurrentNotes(persistentCharacter.Notes);
         combatant.AttachToPersistentCharacterLibrary(updatePersistentCharacter);
       }

--- a/client/Index.ts
+++ b/client/Index.ts
@@ -39,7 +39,6 @@ window.onload = async () => {
 
     viewModel.ImportEncounterIfAvailable();
     viewModel.ImportFromQueryParamIfAvailable();
-    viewModel.GetWhatsNewIfAvailable();
     Metrics.TrackLoad();
   }
 

--- a/client/InitiativeList/CombatantRow.tsx
+++ b/client/InitiativeList/CombatantRow.tsx
@@ -17,6 +17,7 @@ type CombatantRowProps = {
   isSelected: boolean;
   showIndexLabel: boolean;
   initiativeIndex: number;
+  showManaColumn: boolean;
 };
 
 type CombatantDragData = {
@@ -95,11 +96,6 @@ export function CombatantRow(props: CombatantRowProps) {
           <i className="fas fa-grip-vertical" />
         </td>
       }
-      <td className="combatant__initiative" title="Initiative Roll">
-        {props.combatantState.InitiativeGroup && <i className="fas fa-link" />}
-        {props.combatantState.Initiative}
-      </td>
-
       <td aria-hidden="true" className="combatant__image-cell">
         {DisplayPortraits && (
           <img
@@ -164,6 +160,42 @@ export function CombatantRow(props: CombatantRowProps) {
           </div>
         </div>
       </td>
+
+      {props.showManaColumn && (
+        <td className="combatant__mana">
+          {props.combatantState.StatBlock.Mana ? (
+            <div
+              className="combatant__mana-outer"
+              onClick={event => {
+                commandContext.ApplyManaToCombatant(props.combatantState.Id);
+                event.stopPropagation();
+              }}
+            >
+              <div className="combatant__mana-inner" style={getManaStyle(props)}>
+                <span
+                  className="combatant__mobile-icon fas fa-hat-wizard"
+                  aria-hidden="true"
+                />
+
+                {renderManaText(props)}
+                {DisplayHPBar && (
+                  <span className="combatant__hp-bar">
+                    <span
+                      className="combatant__hp-bar--filled"
+                      style={renderManaBarStyle(props)}
+                    />
+                  </span>
+                )}
+              </div>
+            </div>
+          ) : (
+            <span
+              className="combatant__mobile-icon fas fa-hat-wizard"
+              aria-hidden="true"
+            />
+          )}
+        </td>
+      )}
 
       <td className="combatant__ac">
         <span
@@ -352,4 +384,33 @@ function renderHPBarStyle(props: CombatantRowProps) {
   const maxHP = props.combatantState.StatBlock.HP.Value,
     currentHP = props.combatantState.CurrentHP;
   return { width: Math.floor((currentHP / maxHP) * 100) + "%" };
+}
+
+function getManaStyle(props: CombatantRowProps) {
+  const maxMana = props.combatantState.StatBlock.Mana?.Value;
+  if (!maxMana) {
+    return {};
+  }
+  const currentMana = props.combatantState.CurrentMana ?? 0;
+  // Do not set green any higher, low value is needed for contrast against light background
+  const green = Math.floor((currentMana / maxMana) * 120);
+  const red = Math.floor(((maxMana - currentMana) / maxMana) * 170);
+  return { color: "rgb(" + red + "," + green + ",0)" };
+}
+
+function renderManaText(props: CombatantRowProps) {
+  const maxMana = props.combatantState.StatBlock.Mana?.Value;
+  if (!maxMana) {
+    return "";
+  }
+  return `${props.combatantState.CurrentMana ?? 0}/${maxMana}`;
+}
+
+function renderManaBarStyle(props: CombatantRowProps) {
+  const maxMana = props.combatantState.StatBlock.Mana?.Value;
+  if (!maxMana) {
+    return { width: "0%" };
+  }
+  const currentMana = props.combatantState.CurrentMana ?? 0;
+  return { width: Math.floor((currentMana / maxMana) * 100) + "%" };
 }

--- a/client/InitiativeList/CommandContext.tsx
+++ b/client/InitiativeList/CommandContext.tsx
@@ -8,6 +8,7 @@ export const CommandContext = React.createContext({
   SelectCombatant: (combatantId: string, appendSelection: boolean) => {},
   RemoveTagFromCombatant: (combatantId: string, tagState: TagState) => {},
   ApplyDamageToCombatant: (combatantId: string) => {},
+  ApplyManaToCombatant: (combatantId: string) => {},
   MoveCombatantFromDrag: (
     draggedCombatantId: string,
     droppedOntoCombatantId: string | null

--- a/client/InitiativeList/InitiativeList.tsx
+++ b/client/InitiativeList/InitiativeList.tsx
@@ -12,6 +12,9 @@ export function InitiativeList(props: {
   combatantCountsByName: { [name: string]: number };
 }) {
   const encounterState = props.encounterState;
+  const showManaColumn = encounterState.Combatants.some(
+    c => c.StatBlock.Mana
+  );
 
   return (
     <div className="initiative-list">
@@ -19,6 +22,7 @@ export function InitiativeList(props: {
       <table className="combatants">
         <InitiativeListHeader
           encounterActive={encounterState.ActiveCombatantId != null}
+          showManaColumn={showManaColumn}
         />
         <tbody>
           {encounterState.Combatants.map((combatantState, index) => {
@@ -37,6 +41,7 @@ export function InitiativeList(props: {
                 // creature with this name.
                 showIndexLabel={siblingCount > 1}
                 initiativeIndex={index}
+                showManaColumn={showManaColumn}
               />
             );
           })}

--- a/client/InitiativeList/InitiativeListHeader.tsx
+++ b/client/InitiativeList/InitiativeListHeader.tsx
@@ -1,30 +1,16 @@
-import Tippy from "@tippyjs/react";
 import * as React from "react";
 import { SettingsContext } from "../Settings/SettingsContext";
 
-export function InitiativeListHeader(props: { encounterActive: boolean }) {
-  const encounterStateIcon = props.encounterActive ? "fa-play" : "fa-pause";
-  const encounterStateTip = props.encounterActive
-    ? "Encounter Active"
-    : "Encounter Inactive";
-
+export function InitiativeListHeader(props: {
+  encounterActive: boolean;
+  showManaColumn: boolean;
+}) {
   const settings = React.useContext(SettingsContext);
 
   return (
     <thead className="combatant--header">
       <tr>
         <th className="combatant__left-gutter" />
-        <th className="combatant__initiative">
-          <span className="screen-reader-only">Initiative Score</span>
-          <div aria-hidden="true">
-            <Tippy content={encounterStateTip}>
-              <span
-                data-testid="encounter-state-icon"
-                className={"fas " + encounterStateIcon}
-              ></span>
-            </Tippy>
-          </div>
-        </th>
 
         <th className="combatant__image" aria-hidden="true"></th>
 
@@ -41,11 +27,22 @@ export function InitiativeListHeader(props: { encounterActive: boolean }) {
           ></span>
         </th>
 
+        {props.showManaColumn && (
+          <th className="combatant__mana">
+            <span className="screen-reader-only">Mana</span>
+            <span
+              className="fas fa-hat-wizard"
+              title="Mana"
+              aria-hidden="true"
+            ></span>
+          </th>
+        )}
+
         <th className="combatant__ac">
-          <span className="screen-reader-only">Armor Class</span>
+          <span className="screen-reader-only">Defense</span>
           <span
             className="fas fa-shield-alt"
-            title="Armor Class"
+            title="Defense"
             aria-hidden="true"
           ></span>
         </th>

--- a/client/InitiativeList/InitiativeListHost.tsx
+++ b/client/InitiativeList/InitiativeListHost.tsx
@@ -55,6 +55,19 @@ export function InitiativeListHost(props: { tracker: TrackerViewModel }) {
     [tracker]
   );
 
+  const applyManaToCombatant = useCallback(
+    (combatantId: string) => {
+      const combatantViewModel = tracker
+        .CombatantViewModels()
+        .find(c => c.Combatant.Id == combatantId);
+
+      if (combatantViewModel !== undefined) {
+        tracker.CombatantCommander.SpendManaTargeted(combatantViewModel);
+      }
+    },
+    [tracker]
+  );
+
   const moveCombatantFromDrag = useCallback(
     (draggedCombatantId: string, droppedOntoCombatantId: string | null) => {
       const combatants = tracker.Encounter.Combatants();
@@ -101,6 +114,7 @@ export function InitiativeListHost(props: { tracker: TrackerViewModel }) {
         SelectCombatant: selectCombatantById,
         RemoveTagFromCombatant: removeCombatantTag,
         ApplyDamageToCombatant: applyDamageToCombatant,
+        ApplyManaToCombatant: applyManaToCombatant,
         CombatantCommands: tracker.CombatantCommander.Commands,
         MoveCombatantFromDrag: moveCombatantFromDrag,
         SetCombatantColor: setCombatantColor,

--- a/client/Layout/CenterColumn.tsx
+++ b/client/Layout/CenterColumn.tsx
@@ -8,7 +8,6 @@ import { CombatFooter } from "../CombatFooter/CombatFooter";
 import { InitiativeListHost } from "../InitiativeList/InitiativeListHost";
 import { useVerticalResizerDrop } from "./VerticalResizer";
 import { centerColumnView } from "./centerColumnView";
-import { BannerHost } from "./BannerHost";
 
 export function CenterColumn(props: {
   tracker: TrackerViewModel;
@@ -39,7 +38,6 @@ export function CenterColumn(props: {
         encounter={props.tracker.Encounter}
         eventLog={props.tracker.EventLog}
       />
-      <BannerHost />
     </div>
   );
 }

--- a/client/PlayerView/components/PlayerView.tsx
+++ b/client/PlayerView/components/PlayerView.tsx
@@ -59,6 +59,10 @@ export class PlayerView extends React.Component<PlayerViewProps, LocalState> {
       c => c.AC != undefined
     );
 
+    const manaColumnVisible = this.props.encounterState.Combatants.some(
+      c => c.ManaDisplay != undefined
+    );
+
     const modalVisible =
       this.state.showPortrait ||
       this.state.suggestDamageCombatant ||
@@ -110,6 +114,7 @@ export class PlayerView extends React.Component<PlayerViewProps, LocalState> {
         <PlayerViewCombatantHeader
           portraitColumnVisible={this.hasImages()}
           acColumnVisible={acColumnVisible}
+          manaColumnVisible={manaColumnVisible}
         />
         <ul className="combatants">
           {this.props.encounterState.Combatants.map(combatant => (
@@ -124,6 +129,7 @@ export class PlayerView extends React.Component<PlayerViewProps, LocalState> {
               areSuggestionsAllowed={this.props.settings.AllowPlayerSuggestions}
               portraitColumnVisible={this.hasImages()}
               acColumnVisible={acColumnVisible}
+              manaColumnVisible={manaColumnVisible}
               reactionTrackerVisible={
                 this.props.settings.DisplayReactionTracker
               }

--- a/client/PlayerView/components/PlayerViewCombatant.tsx
+++ b/client/PlayerView/components/PlayerViewCombatant.tsx
@@ -8,6 +8,7 @@ interface PlayerViewCombatantProps {
   isActive: boolean;
   portraitColumnVisible: boolean;
   acColumnVisible: boolean;
+  manaColumnVisible: boolean;
   reactionTrackerVisible: boolean;
   colorVisible: boolean;
   areSuggestionsAllowed: boolean;
@@ -29,9 +30,6 @@ export class PlayerViewCombatant extends React.Component<PlayerViewCombatantProp
       this.props.combatant.Color && this.props.combatant.Color.length > 0;
     return (
       <li className={classNames.join(" ")}>
-        <div className="combatant__initiative">
-          {this.props.combatant.Initiative}
-        </div>
         {this.props.portraitColumnVisible && (
           <div className="combatant__portrait">
             {this.props.combatant.ImageURL && (
@@ -64,6 +62,16 @@ export class PlayerViewCombatant extends React.Component<PlayerViewCombatantProp
             dangerouslySetInnerHTML={{ __html: this.props.combatant.HPDisplay }}
           />
         </div>
+        {this.props.manaColumnVisible && (
+          <div className="combatant__mana">
+            <span
+              style={{ color: this.props.combatant.ManaColor }}
+              dangerouslySetInnerHTML={{
+                __html: this.props.combatant.ManaDisplay || ""
+              }}
+            />
+          </div>
+        )}
         {this.props.acColumnVisible && (
           <div className="combatant__ac">{this.props.combatant.AC || ""}</div>
         )}

--- a/client/PlayerView/components/PlayerViewCombatantHeader.tsx
+++ b/client/PlayerView/components/PlayerViewCombatantHeader.tsx
@@ -7,16 +7,19 @@ import {
 export const PlayerViewCombatantHeader = (props: {
   portraitColumnVisible: boolean;
   acColumnVisible: boolean;
+  manaColumnVisible: boolean;
 }) => (
   <div className="combatant--header">
-    <div className="combatant__initiative">
-      <span className="fas fa-forward" />
-    </div>
     {props.portraitColumnVisible && <div className="combatant__portrait" />}
     <div className="combatant__name">Combatant</div>
     <div className="combatant__hp">
       <span className="fas fa-heart" />
     </div>
+    {props.manaColumnVisible && (
+      <div className="combatant__mana">
+        <span className="fas fa-hat-wizard" />
+      </div>
+    )}
     {props.acColumnVisible && (
       <div className="combatant__ac">
         <span className="fas fa-shield-alt" />

--- a/client/Prompts/ApplyManaPrompt.tsx
+++ b/client/Prompts/ApplyManaPrompt.tsx
@@ -1,0 +1,44 @@
+import { Field } from "formik";
+import * as React from "react";
+
+import { CombatantViewModel } from "../Combatant/CombatantViewModel";
+import { PromptProps } from "./PendingPrompts";
+import { StandardPromptLayout } from "./StandardPromptLayout";
+
+interface ApplyManaModel {
+  manaAmount: string;
+}
+
+export const ApplyManaPrompt = (
+  combatantViewModels: CombatantViewModel[],
+  suggestedMana: string,
+  logManaChange: (amount: number, combatantNames: string) => void
+): PromptProps<ApplyManaModel> => {
+  const combatantNames = combatantViewModels.map(c => c.Name()).join(", ");
+  return {
+    onSubmit: (model: ApplyManaModel) => {
+      const manaAmount = parseInt(model.manaAmount);
+      if (isNaN(manaAmount)) {
+        return false;
+      }
+
+      logManaChange(manaAmount, combatantNames);
+
+      combatantViewModels.forEach(c => c.ApplyManaChange(model.manaAmount));
+      return true;
+    },
+
+    initialValues: { manaAmount: suggestedMana },
+
+    autoFocusSelector: ".autofocus",
+
+    children: (
+      <StandardPromptLayout
+        className="p-apply-mana"
+        label={`Spend or restore mana for ${combatantNames}`}
+      >
+        <Field type="number" className="autofocus" name="manaAmount" />
+      </StandardPromptLayout>
+    )
+  };
+};

--- a/client/Prompts/RestoreManaPrompt.tsx
+++ b/client/Prompts/RestoreManaPrompt.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+
+import { Field } from "formik";
+
+import { CombatantViewModel } from "../Combatant/CombatantViewModel";
+import { PromptProps } from "./PendingPrompts";
+import { StandardPromptLayout } from "./StandardPromptLayout";
+
+interface RestoreManaModel {
+  restoreAmount: string;
+}
+
+export const RestoreManaPrompt = (
+  combatantViewModels: CombatantViewModel[],
+  suggestedRestore: string,
+  logManaChange: (amount: number, combatantNames: string) => void
+): PromptProps<RestoreManaModel> => {
+  const combatantNames = combatantViewModels.map(c => c.Name()).join(", ");
+  return {
+    onSubmit: (model: RestoreManaModel) => {
+      const restoreAmount = parseInt(model.restoreAmount);
+      if (isNaN(restoreAmount)) {
+        return false;
+      }
+
+      logManaChange(-restoreAmount, combatantNames);
+
+      combatantViewModels.forEach(c =>
+        c.ApplyManaChange("-" + model.restoreAmount)
+      );
+      return true;
+    },
+
+    initialValues: { restoreAmount: suggestedRestore },
+
+    autoFocusSelector: ".autofocus",
+
+    children: (
+      <StandardPromptLayout label={`Restore mana for ${combatantNames}:`}>
+        <Field type="number" className="autofocus" name="restoreAmount" />
+      </StandardPromptLayout>
+    )
+  };
+};

--- a/client/StatBlockEditor/ConvertStringsToNumbersWhereNeeded.tsx
+++ b/client/StatBlockEditor/ConvertStringsToNumbersWhereNeeded.tsx
@@ -6,6 +6,9 @@ export const ConvertStringsToNumbersWhereNeeded = (statBlock: StatBlock) => {
   );
   statBlock.HP.Value = castToNumberOrZero(statBlock.HP.Value);
   statBlock.AC.Value = castToNumberOrZero(statBlock.AC.Value);
+  if (statBlock.Mana) {
+    statBlock.Mana.Value = castToNumberOrZero(statBlock.Mana.Value);
+  }
   statBlock.InitiativeModifier = castToNumberOrZero(
     statBlock.InitiativeModifier
   );

--- a/client/StatBlockEditor/StatBlockEditor.tsx
+++ b/client/StatBlockEditor/StatBlockEditor.tsx
@@ -190,11 +190,12 @@ export class StatBlockEditor extends React.Component<
             fieldName="Challenge"
           />
           <ValueAndNotesField label="Hit Points" fieldName="HP" />
-          <ValueAndNotesField label="Armor Class" fieldName="AC" />
+          <ValueAndNotesField label="Defense" fieldName="AC" />
+          <ValueAndNotesField label="Mana" fieldName="Mana" />
           <InitiativeField />
         </div>
         <div className="c-statblock-editor__abilityscores">
-          {StatBlock.AbilityNames.map(abilityScoreField)}
+          {StatBlock.VisibleAbilityNames.map(abilityScoreField)}
         </div>
         {settings.StatBlock.CustomFields.length > 0 && (
           <div className="c-statblock-editor__custom-fields">
@@ -215,9 +216,6 @@ export class StatBlockEditor extends React.Component<
         )}
         <div className="c-statblock-editor__saves">
           <NameAndModifierFields api={api} modifierType="Saves" />
-        </div>
-        <div className="c-statblock-editor__skills">
-          <NameAndModifierFields api={api} modifierType="Skills" />
         </div>
         {[
           "Speed",

--- a/client/StatBlockEditor/components/StatBlockEditorFields.tsx
+++ b/client/StatBlockEditor/components/StatBlockEditorFields.tsx
@@ -59,7 +59,9 @@ export const InitiativeField = () => (
 
 export const abilityScoreField = (abilityName: string) => (
   <div key={abilityName} className="c-statblock-editor__ability">
-    <label htmlFor={`ability-${abilityName}`}>{abilityName}</label>
+    <label htmlFor={`ability-${abilityName}`}>
+      {StatBlock.AbilityDisplayNames[abilityName] || abilityName}
+    </label>
     <Field
       type="number"
       id={`ability-${abilityName}`}

--- a/client/TrackerViewModel.tsx
+++ b/client/TrackerViewModel.tsx
@@ -23,7 +23,6 @@ import { Encounter } from "./Encounter/Encounter";
 import { UpdateLegacyEncounterState } from "./Encounter/UpdateLegacySavedEncounter";
 import { env } from "./Environment";
 import { Libraries, LibraryType } from "./Library/Libraries";
-import { PatreonPost } from "../common/PatreonPost";
 import { PlayerViewClient } from "./PlayerView/PlayerViewClient";
 import { DefaultRules } from "./Rules/Rules";
 import {
@@ -38,7 +37,6 @@ import { LegacySynchronousLocalStore } from "./Utility/LegacySynchronousLocalSto
 import { Metrics } from "./Utility/Metrics";
 import { EventLog } from "./Widgets/EventLog";
 import { SpellEditorProps } from "./StatBlockEditor/SpellEditor";
-import axios from "axios";
 import { Spell } from "../common/Spell";
 
 const codec = compression("lzma");
@@ -379,15 +377,6 @@ export class TrackerViewModel {
       onDelete: () => {}
     });
   }
-
-  public GetWhatsNewIfAvailable = (): void => {
-    axios.get<PatreonPost>("/whatsnew/").then(response => {
-      const latestPost = response.data;
-      this.EventLog.AddEvent(
-        `Welcome to Improved Initiative! Here's what's new: [${latestPost.attributes.title}](${latestPost.attributes.url})`
-      );
-    });
-  };
 
   private subscribeToSocketMessages = () => {
     this.Socket.on(

--- a/client/Widgets/EventLog.ts
+++ b/client/Widgets/EventLog.ts
@@ -15,4 +15,13 @@ export class EventLog {
       this.AddEvent(`${-damage} HP restored to ${combatantNames}.`);
     }
   };
+
+  public LogManaChange = (amount: number, combatantNames: string) => {
+    if (amount > 0) {
+      this.AddEvent(`${amount} mana spent by ${combatantNames}.`);
+    }
+    if (amount < 0) {
+      this.AddEvent(`${-amount} mana restored to ${combatantNames}.`);
+    }
+  };
 }

--- a/common/CombatantState.ts
+++ b/common/CombatantState.ts
@@ -14,6 +14,7 @@ export interface CombatantState {
   StatBlock: StatBlock;
   PersistentCharacterId?: string;
   CurrentHP: number;
+  CurrentMana?: number;
   CurrentNotes?: string;
   Color?: string;
   ReactionsSpent?: number;

--- a/common/PersistentCharacter.ts
+++ b/common/PersistentCharacter.ts
@@ -9,6 +9,7 @@ export interface PersistentCharacter {
   Path: string;
   LastUpdateMs: number;
   CurrentHP: number;
+  CurrentMana?: number;
   StatBlock: StatBlock;
   Notes: string;
 }
@@ -22,6 +23,7 @@ export namespace PersistentCharacter {
       Path: statBlock.Path,
       LastUpdateMs: now(),
       CurrentHP: statBlock.HP.Value,
+      CurrentMana: statBlock.Mana?.Value,
       StatBlock: statBlock,
       Notes: ""
     };

--- a/common/PlayerViewCombatantState.ts
+++ b/common/PlayerViewCombatantState.ts
@@ -4,6 +4,8 @@ export interface PlayerViewCombatantState {
   Name: string;
   HPDisplay: string;
   HPColor: string;
+  ManaDisplay?: string;
+  ManaColor?: string;
   Initiative: number;
   Id: string;
   Tags: TagState[];

--- a/common/StatBlock.ts
+++ b/common/StatBlock.ts
@@ -35,6 +35,7 @@ export interface StatBlock extends Listable {
   Type: string;
   HP: ValueAndNotes;
   AC: ValueAndNotes;
+  Mana?: ValueAndNotes;
   Speed: string[];
   Abilities: AbilityScores;
   InitiativeModifier?: number;
@@ -63,6 +64,13 @@ export interface StatBlock extends Listable {
 
 export namespace StatBlock {
   export const AbilityNames = ["Str", "Dex", "Con", "Int", "Wis", "Cha"];
+  export const VisibleAbilityNames = ["Str", "Dex", "Int", "Wis"];
+  export const AbilityDisplayNames: Record<string, string> = {
+    Str: "Str",
+    Dex: "Dex",
+    Int: "Int",
+    Wis: "Wil"
+  };
 
   const BaseTypes = [
     "aberration",

--- a/lesscss/components/combatants.less
+++ b/lesscss/components/combatants.less
@@ -84,7 +84,8 @@
     }
   }
 
-  .combatant .combatant__hp-outer {
+  .combatant .combatant__hp-outer,
+  .combatant .combatant__mana-outer {
     transition: box-shadow @transition-hover;
     &:hover {
       box-shadow: 0 0 0 2px var(--hover-hp-red);
@@ -121,7 +122,8 @@
 // becomes visible for active/selected combatants, or on hover
 .combatant.active,
 .combatant.selected,
-.combatant__hp:hover {
+.combatant__hp:hover,
+.combatant__mana:hover {
   .combatant__hp-bar {
     opacity: 1;
   }
@@ -164,10 +166,10 @@
     display: grid;
     /* prettier-ignore */
     grid-template:
-      "leftgutter init image name           ac           hp"
-      "leftgutter init image divider        divider      divider"
-      "leftgutter init image tagsCommands   tagsCommands tagsCommands" /
-       auto auto auto  minmax(0, 1fr) auto     auto;
+      "leftgutter image name           mana         ac       hp"
+      "leftgutter image divider        divider      divider  divider"
+      "leftgutter image tagsCommands   tagsCommands tagsCommands tagsCommands" /
+       auto auto  minmax(0, 1fr) auto     auto     auto;
 
     &::before {
       content: "";
@@ -217,26 +219,6 @@
   }
 }
 
-.combatant__initiative {
-  width: 1.6rem;
-  justify-content: center;
-  grid-area: init;
-
-  .fa-link:before {
-    font-size: 60%;
-    vertical-align: top;
-  }
-}
-
-.initiative-list .combatant__initiative {
-  @media (max-width: @medium) {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-size: 1.5em;
-  }
-}
-
 .combatant__image-cell {
   grid-area: image;
 
@@ -260,7 +242,7 @@
 }
 
 .combatant__name {
-  width: 30%;
+  width: 15%;
   grid-area: name;
 
   @media (max-width: @medium) {
@@ -289,7 +271,7 @@
 }
 
 .combatant__hp {
-  width: 5rem;
+  width: 4rem;
   justify-content: center;
   grid-area: hp;
 
@@ -305,6 +287,18 @@
   grid-area: ac;
   margin-left: 3px;
   position: relative;
+
+  @media (max-width: @medium) {
+    display: flex;
+    flex-flow: row;
+    justify-content: flex-start;
+  }
+}
+
+.combatant__mana {
+  width: 4rem;
+  justify-content: center;
+  grid-area: mana;
 
   @media (max-width: @medium) {
     display: flex;

--- a/lesscss/components/statblock.less
+++ b/lesscss/components/statblock.less
@@ -31,10 +31,29 @@
 .c-combatant-details__tags {
   flex-direction: row;
   margin-top: @extra-small-spacer;
+}
 
+.c-combatant-details__hp {
+  .stat-label.Mana,
+  .stat-label.Level {
+    margin-left: @medium-spacer;
+  }
+}
+
+.c-combatant-details__tags {
   .stat-value {
     display: block;
     flex: 1;
+  }
+}
+
+.c-combatant-details > .HP.AC.speed.Challenge {
+  flex-direction: row;
+  flex-wrap: wrap;
+  margin-top: @extra-small-spacer;
+
+  .stat-label.Speed {
+    margin-left: @medium-spacer;
   }
 }
 
@@ -145,25 +164,27 @@
     margin-bottom: @extra-small-spacer;
   }
 
+  .stat-label.Speed {
+    margin-left: @medium-spacer;
+  }
+
   .Abilities {
-    justify-content: space-between;
-    margin: @medium-spacer 0;
+    margin: @extra-small-spacer 0;
     flex-direction: row;
-    justify-content: center;
+    justify-content: flex-start;
     flex-wrap: wrap;
 
     .Ability {
-      flex-basis: calc(100% / 6);
+      flex: 0 0 auto;
       display: block;
-      text-align: center;
+      text-align: left;
+      margin-right: @medium-spacer;
     }
 
     .stat-label {
-      display: block;
+      display: inline-block;
       text-align: center;
-      margin-right: 0;
-      flex-basis: 100%;
-      margin-bottom: @extra-small-spacer;
+      margin-right: @small-spacer;
       font-size: @font-size-small;
       text-transform: uppercase;
     }
@@ -173,17 +194,6 @@
       display: inline-block;
       font-size: @font-size-small;
       text-align: center;
-    }
-
-    .modifier {
-      &:before {
-        margin-left: @extra-small-spacer;
-        content: "(";
-      }
-
-      &:after {
-        content: ")";
-      }
     }
   }
 
@@ -229,12 +239,7 @@
       }
 
       > .stat-label {
-        font-style: italic;
         color: var(--text-face);
-
-        &:after {
-          content: ".";
-        }
       }
       div {
         display: block;

--- a/lesscss/pages/player-view.less
+++ b/lesscss/pages/player-view.less
@@ -31,7 +31,12 @@
   }
 
   .combatant__hp {
-    flex-basis: 10%;
+    flex-basis: 6%;
+    align-items: center;
+  }
+
+  .combatant__mana {
+    flex-basis: 6%;
     align-items: center;
   }
 
@@ -54,7 +59,7 @@
   }
 
   .combatant__name {
-    flex-basis: 30%;
+    flex-basis: 15%;
     flex-direction: row;
   }
 
@@ -73,11 +78,6 @@
 
   .combatant__header .combatant__tags {
     text-align: center;
-  }
-
-  .combatant__initiative {
-    align-items: flex-end;
-    padding-right: @medium-spacer;
   }
 
   .combat-footer {


### PR DESCRIPTION
- Hide affiliate banners and the "what's new" welcome message
- Adapt ability scores for Nimble: hide Con/Cha, relabel Wis to Wil, hide Skills, rename Armor Class to Defense, hide Proficiency Bonus
- Add a full Mana resource (StatBlock field, per-combatant tracking, spend/restore prompts and commands, initiative list column, Player View display, persistence across remove/re-add for PCs)
- Various stat block, combatant detail, and initiative list layout tweaks (line grouping, spacing, ordering, monster ability-score visibility)