### PR TITLE
Fix combatant action click even propagation

### DIFF
--- a/client/InitiativeList/CombatantRow.test.tsx
+++ b/client/InitiativeList/CombatantRow.test.tsx
@@ -1,0 +1,210 @@
+import { fireEvent, render } from "@testing-library/react";
+import * as React from "react";
+
+import { CombatantState } from "../../common/CombatantState";
+import { getDefaultSettings } from "../../common/Settings";
+import { StatBlock } from "../../common/StatBlock";
+import { Command } from "../Commands/Command";
+import { DefaultRules } from "../Rules/Rules";
+import { SettingsContext } from "../Settings/SettingsContext";
+import {
+  TextEnricher,
+  TextEnricherContext
+} from "../TextEnricher/TextEnricher";
+import { CombatantRow } from "./CombatantRow";
+import { CommandContext } from "./CommandContext";
+
+jest.mock("react-dnd", () => ({
+  useDrag: () => [{}, jest.fn()],
+  useDrop: () => [{ id: null, initiativeIndex: null }, jest.fn()]
+}));
+
+function getCombatantState(
+  overrides: Partial<CombatantState> = {}
+): CombatantState {
+  const statBlock = StatBlock.Default();
+  return {
+    Id: "combatant-id",
+    StatBlock: statBlock,
+    CurrentHP: statBlock.HP.Value,
+    TemporaryHP: 0,
+    Initiative: 10,
+    Alias: "",
+    IndexLabel: null,
+    Tags: [],
+    Hidden: false,
+    RevealedAC: false,
+    InterfaceVersion: "test",
+    ...overrides
+  };
+}
+
+function getCommandContext(
+  overrides: Partial<React.ContextType<typeof CommandContext>> = {}
+): React.ContextType<typeof CommandContext> {
+  return {
+    SelectCombatant: jest.fn(),
+    RemoveTagFromCombatant: jest.fn(),
+    ApplyDamageToCombatant: jest.fn(),
+    MoveCombatantFromDrag: jest.fn(),
+    SetCombatantColor: jest.fn(),
+    ToggleCombatantSpentReaction: jest.fn(),
+    CombatantsPendingRemove: [],
+    RestoreCombatants: jest.fn(),
+    FlushCombatants: jest.fn(),
+    CombatantCommands: [],
+    ...overrides
+  };
+}
+
+function renderCombatantRow(options?: {
+  combatantState?: CombatantState;
+  commandContext?: React.ContextType<typeof CommandContext>;
+  displayReactionTracker?: boolean;
+  textEnricher?: TextEnricher;
+}) {
+  const settings = getDefaultSettings();
+  settings.TrackerView.DisplayReactionTracker =
+    options?.displayReactionTracker || false;
+
+  const row = (
+    <CommandContext.Provider
+      value={options?.commandContext || getCommandContext()}
+    >
+      <SettingsContext.Provider value={settings}>
+        <table>
+          <tbody>
+            <CombatantRow
+              combatantState={options?.combatantState || getCombatantState()}
+              isActive={false}
+              isSelected
+              showIndexLabel={false}
+              initiativeIndex={0}
+            />
+          </tbody>
+        </table>
+      </SettingsContext.Provider>
+    </CommandContext.Provider>
+  );
+
+  if (options?.textEnricher) {
+    return render(
+      <TextEnricherContext.Provider value={options.textEnricher}>
+        {row}
+      </TextEnricherContext.Provider>
+    );
+  }
+  return render(row);
+}
+
+describe("CombatantRow", () => {
+  test("does not select the combatant when an inline command is clicked", () => {
+    const selectCombatant = jest.fn();
+    const runCommand = jest.fn();
+    const command = new Command({
+      id: "link-initiative",
+      description: "Link Initiative",
+      actionBinding: runCommand,
+      fontAwesomeIcon: "link",
+      defaultShowInCombatantRow: true
+    });
+    const rendered = renderCombatantRow({
+      commandContext: getCommandContext({
+        SelectCombatant: selectCombatant,
+        CombatantCommands: [command]
+      })
+    });
+
+    fireEvent.click(rendered.getByRole("button", { name: "Link Initiative" }));
+
+    expect(runCommand).toHaveBeenCalledTimes(1);
+    expect(selectCombatant).not.toHaveBeenCalled();
+  });
+
+  test.each([undefined, 1])(
+    "does not select the combatant when toggling reaction state %s",
+    reactionsSpent => {
+      const selectCombatant = jest.fn();
+      const toggleReaction = jest.fn();
+      const rendered = renderCombatantRow({
+        combatantState: getCombatantState({ ReactionsSpent: reactionsSpent }),
+        commandContext: getCommandContext({
+          SelectCombatant: selectCombatant,
+          ToggleCombatantSpentReaction: toggleReaction
+        }),
+        displayReactionTracker: true
+      });
+
+      fireEvent.click(
+        rendered.container.querySelector(".combatant__reaction-icon")!
+      );
+
+      expect(toggleReaction).toHaveBeenCalledWith("combatant-id");
+      expect(selectCombatant).not.toHaveBeenCalled();
+    }
+  );
+
+  test("does not select the combatant when opening a condition reference", () => {
+    const selectCombatant = jest.fn();
+    const referenceCondition = jest.fn();
+    const textEnricher = new TextEnricher(
+      jest.fn(),
+      jest.fn(),
+      referenceCondition,
+      () => [],
+      () => new RegExp("$^"),
+      new DefaultRules()
+    );
+    const rendered = renderCombatantRow({
+      combatantState: getCombatantState({
+        Tags: [
+          {
+            Text: "Prone",
+            DurationRemaining: -1,
+            DurationTiming: "StartOfTurn",
+            DurationCombatantId: ""
+          }
+        ]
+      }),
+      commandContext: getCommandContext({ SelectCombatant: selectCombatant }),
+      textEnricher
+    });
+
+    fireEvent.click(rendered.container.querySelector(".condition-reference")!);
+
+    expect(referenceCondition).toHaveBeenCalledWith("Prone");
+    expect(selectCombatant).not.toHaveBeenCalled();
+  });
+
+  test("still selects the combatant when plain tag text is clicked", () => {
+    const selectCombatant = jest.fn();
+    const rendered = renderCombatantRow({
+      combatantState: getCombatantState({
+        Tags: [
+          {
+            Text: "Concentrating",
+            DurationRemaining: -1,
+            DurationTiming: "StartOfTurn",
+            DurationCombatantId: ""
+          }
+        ]
+      }),
+      commandContext: getCommandContext({ SelectCombatant: selectCombatant })
+    });
+
+    fireEvent.click(rendered.container.querySelector(".tag__text")!);
+
+    expect(selectCombatant).toHaveBeenCalledWith("combatant-id", false);
+  });
+
+  test("selects the combatant when the row itself is clicked", () => {
+    const selectCombatant = jest.fn();
+    const rendered = renderCombatantRow({
+      commandContext: getCommandContext({ SelectCombatant: selectCombatant })
+    });
+
+    fireEvent.click(rendered.getByRole("row"));
+
+    expect(selectCombatant).toHaveBeenCalledWith("combatant-id", false);
+  });
+});

--- a/client/InitiativeList/CombatantRow.tsx
+++ b/client/InitiativeList/CombatantRow.tsx
@@ -213,32 +213,26 @@ export function CombatantRow(props: CombatantRowProps) {
   );
 }
 
-function ReactionIndicator(props: { combatantState: CombatantState }) {
+function ReactionIndicator({
+  combatantState
+}: {
+  combatantState: CombatantState;
+}) {
   const commandContext = React.useContext(CommandContext);
+  const toggleReaction = (event: React.MouseEvent<HTMLSpanElement>) => {
+    event.stopPropagation();
+    commandContext.ToggleCombatantSpentReaction(combatantState.Id);
+  };
+  const icon = combatantState.ReactionsSpent ? "minus" : "reply";
 
-  if (!props.combatantState.ReactionsSpent) {
-    return (
-      <Tippy content="Reaction">
-        <span
-          className="combatant__reaction-icon fas fa-reply"
-          onClick={() =>
-            commandContext.ToggleCombatantSpentReaction(props.combatantState.Id)
-          }
-        />
-      </Tippy>
-    );
-  } else {
-    return (
-      <Tippy content="Reaction">
-        <span
-          className="combatant__reaction-icon fas fa-minus"
-          onClick={() =>
-            commandContext.ToggleCombatantSpentReaction(props.combatantState.Id)
-          }
-        />
-      </Tippy>
-    );
-  }
+  return (
+    <Tippy content="Reaction">
+      <span
+        className={`combatant__reaction-icon fas fa-${icon}`}
+        onClick={toggleReaction}
+      />
+    </Tippy>
+  );
 }
 
 function CombatantColorPicker(props: { combatantState: CombatantState }) {
@@ -303,7 +297,10 @@ function CommandButton(props: { command: Command }) {
         className={
           "combatant__command-button fa-clickable fa-" + fontAwesomeIcon
         }
-        onClick={command.ActionBinding}
+        onClick={event => {
+          event.stopPropagation();
+          command.ActionBinding();
+        }}
         aria-label={command.Description}
       ></button>
     </Tippy>

--- a/client/TextEnricher/TextEnricher.tsx
+++ b/client/TextEnricher/TextEnricher.tsx
@@ -148,7 +148,10 @@ export class TextEnricher {
           <span
             className="condition-reference"
             key={key}
-            onClick={() => this.referenceCondition(rawText)}
+            onClick={event => {
+              event.stopPropagation();
+              this.referenceCondition(rawText);
+            }}
           >
             {rawText}
           </span>

--- a/lesscss/components/combatants.less
+++ b/lesscss/components/combatants.less
@@ -344,6 +344,11 @@
 .combatant__reaction-icon {
   align-self: center;
   padding: @small-spacer;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--button-text-hover);
+  }
 }
 
 .combatant__tags {


### PR DESCRIPTION
Hey! There's currently a subtle issue: when I click on some combatant row controls, like the inline reaction toggle, inline link initiative button or condition reference tag, it changes the current combatant selection.

For reactions and conditions, it's just inconvenient, but for the "link initiative" it's actually a bug (the inline button doesn't work).

Also, Select Next/Previous buttons didn't work, as they reselected the original row right back :)

**Note:** developed with AI assistance, but fully proofread, refactored and tested personally.

## Summary

- Prevent inline commands from selecting their combatant row.
- Prevent reaction toggles from selecting their combatant row.
- Prevent condition references inside tags from selecting the row.
- Add pointer and red-hover styling to the reaction indicator (just for smoother UX).
- Add unit tests for those.

## Visuals

Only the reaction toggle changed visually:
<img width="277" height="139" alt="image" src="https://github.com/user-attachments/assets/27c4b32d-5a7f-4074-ac38-e99164257425" />

Dark mode:
<img width="224" height="107" alt="image" src="https://github.com/user-attachments/assets/a2469a7c-a458-4b9c-807d-8d072563e948" />


## Manual testing

- [x] Select a combatant and click its inline Link Initiative control, verify the linking mode is active.
- [x] Select the target combatant and verify initiative is linked without linking the source to itself.
- [x] Enable Select Next and Select Previous as inline commands and verify their resulting selection is not reverted.
- [x] Enable the reaction tracker and toggle an unspent reaction.
- [x] Toggle the reaction back from its spent state.
- [x] Verify reaction toggling does not change the selected combatant.
- [x] Verify the reaction icon uses the pointer cursor and turns red on hover.
- [x] Add a condition tag such as Prone and click the condition name; verify the condition prompt opens without changing the selected combatant.
- [x] Click ordinary, non-condition tag text and verify the row is still selected normally.
- [x] Click the row body and verify normal row selection remains unchanged.

Lemme know what'ya think! Cheers! ✌️ 