### PR TITLE
Validate that BASE_URL is an absolute URL at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Linting happens automatically on commit, but you can also run it manually via: `
 
 ### App Settings
 
-You can configure your instance of Improved Initiative with these settings. All are optional, basic functionality should work if you don't specify any.
+You can configure your instance of Improved Initiative with these settings. They are optional under `npm run dev`, which supplies development defaults; when you run the server yourself, `BASE_URL` is required and the rest are optional.
 
 - `PORT` - Defaults to 80
 - `NODE_ENV` - Set to "production" to satisfy react, set to "development" to disable html view caching.
-- `BASE_URL` - Used in absolute URLs on client side. Falls back to relative urls if unavailable. This is the canonical URL for Patreon callback and browser localStorage.
+- `BASE_URL` - The canonical absolute URL of your instance, including the scheme, for example `http://localhost:3000`. Used in absolute URLs on the client side, the Patreon callback, and browser localStorage. The server refuses to start if it is missing or is not an absolute URL.
 - `SESSION_SECRET` - Used to keep session continuity through app restarts or something. Handed to express-session.
 - `DEFAULT_ACCOUNT_LEVEL` - Set to "accountsync" or "epicinitiative" to grant rewards to all users. Useful if you have no DB.
 - `DEFAULT_PATREON_ID` - Set the dummy Patreon user id when running with `DEFAULT_ACCOUNT_LEVEL` set.

--- a/server/getBaseUrlError.test.ts
+++ b/server/getBaseUrlError.test.ts
@@ -1,0 +1,22 @@
+import { getBaseUrlError } from "./getBaseUrlError";
+
+describe("getBaseUrlError", () => {
+  test("accepts an absolute URL", () => {
+    expect(getBaseUrlError("http://localhost:3000")).toBeNull();
+    expect(getBaseUrlError("https://www.improvedinitiative.app")).toBeNull();
+  });
+
+  test("rejects a missing BASE_URL", () => {
+    expect(getBaseUrlError(undefined)).toContain("is not set");
+    expect(getBaseUrlError("")).toContain("is not set");
+  });
+
+  test("rejects a value that cannot resolve a request path", () => {
+    expect(getBaseUrlError("localhost:3000")).toContain("absolute URL");
+    expect(getBaseUrlError("localhost:3000")).toContain("localhost:3000");
+    expect(getBaseUrlError("www.improvedinitiative.app")).toContain(
+      "absolute URL"
+    );
+    expect(getBaseUrlError("http://")).toContain("absolute URL");
+  });
+});

--- a/server/getBaseUrlError.ts
+++ b/server/getBaseUrlError.ts
@@ -1,0 +1,21 @@
+import { URL } from "url";
+
+// "localhost:3000" parses on its own as a URL with the scheme "localhost:", so
+// resolve a path against the value, which is what the routes do with it.
+export function getBaseUrlError(baseUrl: string | undefined): string | null {
+  if (!baseUrl?.length) {
+    return "BASE_URL environment variable is not set. Cannot start server.";
+  }
+
+  try {
+    new URL("/", baseUrl);
+  } catch {
+    return (
+      `BASE_URL environment variable "${baseUrl}" must be an absolute URL ` +
+      `with a scheme and a host, for example "http://localhost:3000". ` +
+      `Cannot start server.`
+    );
+  }
+
+  return null;
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -23,6 +23,7 @@ import { AccountStatus } from "./user";
 import { configureOpen5eContent } from "./configureOpen5eContent";
 import { configureAffiliateRoutes } from "./configureAffiliateRoutes";
 import { configureImportRoutes } from "./configureImportRoutes";
+import { getBaseUrlError } from "./getBaseUrlError";
 
 const baseUrl = process.env.BASE_URL || "";
 const patreonClientId = process.env.PATREON_CLIENT_ID || "PATREON_CLIENT_ID";
@@ -83,10 +84,9 @@ export default async function (
     cacheMaxAge = 0;
   }
 
-  if (!process.env.BASE_URL?.length) {
-    console.error(
-      "BASE_URL environment variable is not set. Cannot start server."
-    );
+  const baseUrlError = getBaseUrlError(process.env.BASE_URL);
+  if (baseUrlError) {
+    console.error(baseUrlError);
     process.exit(1);
   }
 


### PR DESCRIPTION
Refs #682.

### The bug

`server/routes.ts` caches `const baseUrl = process.env.BASE_URL || ""` at module load, and the `GET /e/:id` handler resolves the incoming request against it to read the query string:

```ts
const urlObject = new URL(req.url, baseUrl);
```

907b17d added a startup guard for a *missing* `BASE_URL`, which covers the empty case. It doesn't cover a scheme-less one. Set `BASE_URL=localhost:3000` (a natural thing to type, and the shape most `host:port` env vars take) and the server starts happily, then every "Build an encounter" click and every shared `/e/:id` link 500s:

```
TypeError: Invalid URL
    at new URL (node:internal/url)
    at .../server/routes.js
```

Reproduced on `development` @ a2fd92f by compiling `server/` and running `NODE_ENV=development PORT=3457 BASE_URL=localhost:3457 SKIP_OPEN5E_API=1 node server/server.js`. The server launched, and `GET /e/abc123` returned a 500 with the trace above.

### Why the startup guard rather than the route

The one-line alternative is to stop using `baseUrl` as the base in that handler, since only `.search` is read. That fixes the crash and hides the cause. The same scheme-less value also lands in the Patreon `redirect_uri` (`routes.ts:43`), in the player-view URL handed to actual players (`client/Prompts/PlayerViewPrompt.tsx`), and in `window.location.href` during the canonical-URL transfer (`client/Utility/TransferLocalStorage.ts`). Patching `/e/:id` would silence the one failure loud enough to notice and leave the quiet ones. So this extends your existing guard instead of adding a rival mechanism, and leaves the handler alone.

### The fix

Reject any `BASE_URL` the routes can't actually use, and name the offending value:

```
BASE_URL environment variable "localhost:3000" must be an absolute URL with a scheme and a host, for example "http://localhost:3000". Cannot start server.
```

The check is `new URL("/", baseUrl)`, not `new URL(baseUrl)`. `new URL("localhost:3000")` **succeeds** — it parses as a URL whose scheme is `localhost:` — and only fails when used as a base. Running the same operation the routes run means the guard can't reject a value that used to work: if the app could serve `/e/:id` with a given `BASE_URL` before, it still starts with it now. `https://example.com/ii`, `http://[::1]:3000`, and trailing slashes all pass.

Two boundaries I drew deliberately, happy to move either:

- Non-HTTP schemes (`file://`, `ws://`) pass, because the routes genuinely work with them. The rule is "validate exactly the runtime precondition", not "guess what looks like a website".
- A trailing slash passes validation but still yields a double slash in the Patreon `redirect_uri` via string concatenation. That's pre-existing and unrelated to #682, so I left it.

It's in its own module so it can be unit-tested without dragging `routes.ts`'s import graph (mongo, redis, patreon) into jest, matching `getDbConnectionString.ts` and `fetchRemoteText.ts`.

### Verified

- `npm test` green: 45 suites, 233 passed, 2 todo.
- eslint and prettier clean on the touched files; `tsc -p server/tsconfig.json` clean.
- Before: server starts on `BASE_URL=localhost:3457`, `GET /e/abc123` → 500 `TypeError: Invalid URL`.
- After: same env exits 1 with the message above.
- No regression: on `BASE_URL=http://localhost:3457`, `GET /e/abc123?x=1` → `302 /e/?x=1`, same as before.
- The tests kill both the naive `new URL(baseUrl)` version and a `baseUrl.includes("://")` version.

One upgrade note worth stating: an operator running `BASE_URL=localhost:3000` today gets a server that boots and 500s on `/e/:id`. After this they get no server at all, with a message telling them what to fix. That's the intended cure and matches 907b17d, but it is a behavior change.

### On #682 and the README

I linked #682 rather than using a closing keyword, since I can't tell from the report which `BASE_URL` the reporter had. Between 907b17d and this, both the unset and the scheme-less case now fail at startup with a message that says what to fix, so I think it's covered. Your call on closing.

The README hunk is two lines. The App Settings list still says `BASE_URL` "Falls back to relative urls if unavailable", which stopped being true with 907b17d, and "All are optional" is now only true under `npm run dev` (which supplies the default via `scripts/dev-server.cjs`). Adding a new way for the server to refuse to boot while the docs call the variable optional seemed like the next bug report, but happy to drop it if you'd rather keep this to the code.

---

Disclosure: I used an AI assistant while working on this. The bug, the reproduction, the fix and the tests were all verified by hand against a running server before opening this.