### PR TITLE
Fix dice rolls possibly returning zero

### DIFF
--- a/client/Commands/CombatantCommander.test.ts
+++ b/client/Commands/CombatantCommander.test.ts
@@ -101,9 +101,9 @@ describe("CombatantCommander", () => {
   test("rerolls the original dice expression", () => {
     const random = jest
       .spyOn(Math, "random")
-      .mockReturnValueOnce(0.01)
+      .mockReturnValueOnce(0)
       .mockReturnValueOnce(0.2)
-      .mockReturnValue(1);
+      .mockReturnValue(0.999999);
 
     try {
       combatantCommander.RollDice("2d6 + 3");

--- a/client/Encounter/AutoRerollInitiativeOption.test.ts
+++ b/client/Encounter/AutoRerollInitiativeOption.test.ts
@@ -45,7 +45,7 @@ describe("AutoRerollInitiativeOption", () => {
       }
     });
     const promptReroll = jest.fn();
-    Math.random = () => 1;
+    Math.random = () => 0.999999;
     const encounter = runEncounter(promptReroll);
     expect(encounter.Combatants()[0].Initiative()).toEqual(20);
     expect(encounter.Combatants()[1].Initiative()).toEqual(20);

--- a/client/Rules/Dice.test.ts
+++ b/client/Rules/Dice.test.ts
@@ -1,0 +1,30 @@
+import { rollDie } from "./Dice";
+
+describe("rollDie", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("returns values from one through the die size", () => {
+    jest
+      .spyOn(Math, "random")
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0.25)
+      .mockReturnValueOnce(0.5)
+      .mockReturnValueOnce(0.75);
+
+    expect([rollDie(4), rollDie(4), rollDie(4), rollDie(4)]).toEqual([
+      1, 2, 3, 4
+    ]);
+  });
+
+  test("returns the minimum and maximum d20 values", () => {
+    jest
+      .spyOn(Math, "random")
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0.999999);
+
+    expect(rollDie(20)).toBe(1);
+    expect(rollDie(20)).toBe(20);
+  });
+});

--- a/client/Rules/Dice.ts
+++ b/client/Rules/Dice.ts
@@ -1,5 +1,8 @@
 import { RollResult } from "./RollResult";
 
+export const rollDie = (size: number): number =>
+  Math.floor(Math.random() * size) + 1;
+
 export class Dice {
   public static readonly ValidDicePattern =
     /(\d+)d(\d+)[\s]*([+-][\s]*\d+)?|([+-][\s]*\d+)/;
@@ -14,14 +17,14 @@ export class Dice {
     const isLooseModifier = typeof match[4] == "string";
     if (match[4] && isLooseModifier) {
       const modifier = parseInt(match[4].replace(/[\s]*/g, ""));
-      const d20Roll = Math.ceil(Math.random() * 20);
+      const d20Roll = rollDie(20);
       return new RollResult([d20Roll], modifier, 20);
     }
     const howMany = typeof match[1] == "undefined" ? 1 : parseInt(match[1]);
     const dieSize = parseInt(match[2]);
     const rolls: number[] = [];
     for (let i = 0; i < howMany; i++) {
-      rolls[i] = Math.ceil(Math.random() * dieSize);
+      rolls[i] = rollDie(dieSize);
     }
     const modifier =
       typeof match[3] == "undefined"

--- a/client/Rules/Rules.test.ts
+++ b/client/Rules/Rules.test.ts
@@ -7,6 +7,10 @@ describe("DefaultRules", () => {
     rules = new DefaultRules();
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test("Ability Score 0", () => {
     expect(rules.GetModifierFromScore(0)).toBe(-5);
   });
@@ -20,29 +24,35 @@ describe("DefaultRules", () => {
   });
 
   test("Roll with advantage", () => {
-    Math.random = jest
-      .fn()
-      .mockReturnValueOnce(5 / 20)
-      .mockReturnValueOnce(15 / 20);
+    jest
+      .spyOn(Math, "random")
+      .mockReturnValueOnce(4 / 20)
+      .mockReturnValueOnce(14 / 20);
     const roll = rules.AbilityCheck(0, "advantage");
     expect(roll).toEqual({ rolls: [5, 15], finalValue: 15 });
   });
 
   test("Roll with disadvantage", () => {
-    Math.random = jest
-      .fn()
-      .mockReturnValueOnce(5 / 20)
-      .mockReturnValueOnce(15 / 20);
+    jest
+      .spyOn(Math, "random")
+      .mockReturnValueOnce(4 / 20)
+      .mockReturnValueOnce(14 / 20);
     const roll = rules.AbilityCheck(0, "disadvantage");
     expect(roll).toEqual({ rolls: [5, 15], finalValue: 5 });
   });
 
   test("Roll with take ten", () => {
-    Math.random = jest
-      .fn()
-      .mockReturnValueOnce(5 / 20)
-      .mockReturnValueOnce(15 / 20);
+    jest.spyOn(Math, "random");
     const roll = rules.AbilityCheck(0, "take-ten");
     expect(roll).toEqual({ rolls: [], finalValue: 10 });
+    expect(Math.random).not.toHaveBeenCalled();
+  });
+
+  test("Roll the minimum d20 value when Math.random returns zero", () => {
+    jest.spyOn(Math, "random").mockReturnValue(0);
+
+    const roll = rules.AbilityCheck();
+
+    expect(roll).toEqual({ rolls: [1], finalValue: 1 });
   });
 });

--- a/client/Rules/Rules.ts
+++ b/client/Rules/Rules.ts
@@ -1,5 +1,6 @@
 import * as _ from "lodash";
 import { InitiativeSpecialRoll } from "../../common/StatBlock";
+import { rollDie } from "./Dice";
 
 export type AbilityCheckResult = {
   rolls: number[];
@@ -35,7 +36,7 @@ export class DefaultRules implements IRules {
 
   public AbilityCheck = (mod = 0, specialRoll?: InitiativeSpecialRoll) => {
     if (specialRoll == "advantage") {
-      const rolls = [rollD20(), rollD20()];
+      const rolls = [rollDie(20), rollDie(20)];
       return {
         rolls,
         finalValue: _.max(rolls) + mod
@@ -43,7 +44,7 @@ export class DefaultRules implements IRules {
     }
 
     if (specialRoll == "disadvantage") {
-      const rolls = [rollD20(), rollD20()];
+      const rolls = [rollDie(20), rollDie(20)];
       return {
         rolls,
         finalValue: _.min(rolls) + mod
@@ -57,7 +58,7 @@ export class DefaultRules implements IRules {
       };
     }
 
-    const roll = rollD20();
+    const roll = rollDie(20);
     return {
       rolls: [roll],
       finalValue: roll + mod
@@ -65,8 +66,4 @@ export class DefaultRules implements IRules {
   };
 
   public EnemyHPTransparency = "whenBloodied";
-}
-
-function rollD20(): number {
-  return Math.ceil(Math.random() * 20);
 }


### PR DESCRIPTION
Hey,  as I was working on the advantage/disadvantage, I noticed this small bug.

The die roll expression was `Math.ceil(Math.random() * dieSize)` - it could theoretically return `0` when [Math.random()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random) returns exactly `0`.

> The Math.random() static method returns a floating-point, pseudo-random number that's greater than or **_equal_** to 0 and less than 1

Extremely unlikely, but nevertheless possible :) 

I introduced a shared `rollDie(size)` function using `Math.floor(Math.random() * size) + 1` to guarantee results between `1` and the die size.

## Manual Testing

Virtually impossible to reproduce due to randomness, so performed smoke testing.

- [x] Open the Roll Dice prompt and roll `1d20`; verify the result is between 1 and 20.
- [x] Roll `2d6 + 3`; verify each die is between 1 and 6 and the modifier is included in the total.
- [x] Reroll a dice-result prompt; verify the expression remains unchanged and the new dice remain within range.
- [x] Roll initiative normally; verify the result uses a value between 1 and 20.
- [x] Roll initiative with advantage; verify two valid d20 values are generated and the higher result is used.
- [x] Roll initiative with disadvantage; verify two valid d20 values are generated and the lower result is used.